### PR TITLE
delete lock file when package is updated

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -33,6 +33,7 @@ class Launcher {
 
         this.files = {
             packageJSON: path.join(this.projectDir, 'package.json'),
+            packageLockJSON: path.join(this.projectDir, 'package-lock.json'),
             flows: path.join(this.projectDir, 'flows.json'),
             credentials: path.join(this.projectDir, 'flows_cred.json'),
             settings: path.join(this.projectDir, 'settings.js'),
@@ -54,6 +55,13 @@ class Launcher {
         await fs.writeFile(this.files.packageJSON, JSON.stringify(packageData, ' ', 2))
         await fs.rm(path.join(this.projectDir, '.config.nodes.json'), { force: true })
         await fs.rm(path.join(this.projectDir, '.config.nodes.json.backup'), { force: true })
+
+        // as the package.json file has been re-written, we will "assume" different versions
+        // of the modules and therefore remove the package-lock.json file to permit modules
+        // to be updated to the versions specified in package.json
+        if (existsSync(this.files.packageLockJSON)) {
+            await fs.rm(this.files.packageLockJSON)
+        }
     }
 
     async readPackage () {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -59,6 +59,10 @@ class Launcher {
         // as the package.json file has been re-written, we will "assume" different versions
         // of the modules and therefore remove the package-lock.json file to permit modules
         // to be updated to the versions specified in package.json
+        await this.removePackageLock()
+    }
+
+    async removePackageLock () {
         if (existsSync(this.files.packageLockJSON)) {
             await fs.rm(this.files.packageLockJSON)
         }

--- a/test/unit/lib/launcher_spec.js
+++ b/test/unit/lib/launcher_spec.js
@@ -1,3 +1,4 @@
+const sinon = require('sinon')
 const should = require('should')
 const { newLauncher } = require('../../../lib/launcher')
 const setup = require('../setup')
@@ -23,6 +24,7 @@ describe('Launcher', function () {
 
     afterEach(async function () {
         await fs.rm(config.dir, { recursive: true, force: true })
+        sinon.restore()
     })
 
     it('Create Snapshot Flow/Creds Files, instance bound device', async function () {
@@ -91,6 +93,8 @@ describe('Launcher', function () {
 
     it('Write package.json', async function () {
         const launcher = newLauncher(config, null, 'projectId', setup.snapshot)
+        // spy on the removePackageLock function
+        sinon.spy(launcher, 'removePackageLock')
         await launcher.writePackage()
         const pkgFile = await fs.readFile(path.join(config.dir, 'project', 'package.json'))
         const pkg = JSON.parse(pkgFile)
@@ -98,6 +102,7 @@ describe('Launcher', function () {
         pkg.dependencies.should.have.property('node-red-node-random', '0.4.0')
         pkg.name.should.eqls('TEST_PROJECT')
         pkg.version.should.eqls('0.0.0-aaaabbbbcccc')
+        launcher.removePackageLock.calledOnce.should.be.true()
     })
 
     it('Write Settings - with HTTPS, raw values', async function () {


### PR DESCRIPTION
## Description

Deletes package lock when the package is updated.
This permits the internal call to `npm install --production` to get specified versions instead of the lock versions.

### TODO:

- [x] test package is deleted.

## Related Issue(s)

#178 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

