### PR TITLE
Ensure that tunneled payloads are parsed

### DIFF
--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -169,10 +169,11 @@ class EditorTunnel {
                     // ↓ useful for debugging but very noisy
                     // console.log('Making a request to:', fullUrl, 'x-access-token:', request.method, reqHeaders['x-access-token'])
                     // debug(`proxy [${request.method}] ${fullUrl}`)
+                    // debug(`body ${request.body}`)
                     const options = {
                         headers: reqHeaders,
                         method: request.method,
-                        body: request.body,
+                        body: request.body ? JSON.parse(request.body) : undefined,
                         throwErrors: false
                     }
                     if (thisTunnel.localProtocol === 'https') {

--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -170,10 +170,10 @@ class EditorTunnel {
                     // console.log('Making a request to:', fullUrl, 'x-access-token:', request.method, reqHeaders['x-access-token'])
                     // debug(`proxy [${request.method}] ${fullUrl}`)
                     // debug(`body ${request.body}`)
-                    let body  = request.body
+                    let body = request.body
                     try {
-                        let temp = JSON.parse(body)
-                        if (typeof temp === "string") {
+                        const temp = JSON.parse(body)
+                        if (typeof temp === 'string') {
                             body = temp
                         }
                     } catch (err) {
@@ -182,7 +182,7 @@ class EditorTunnel {
                     const options = {
                         headers: reqHeaders,
                         method: request.method,
-                        body: body,
+                        body,
                         throwErrors: false
                     }
                     if (thisTunnel.localProtocol === 'https') {

--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -171,13 +171,12 @@ class EditorTunnel {
                     // debug(`proxy [${request.method}] ${fullUrl}`)
                     // debug(`body ${request.body}`)
                     let body = request.body
-                    try {
-                        const temp = JSON.parse(body)
-                        if (typeof temp === 'string') {
-                            body = temp
+                    if (body && body[0] === '"') {
+                        try {
+                            body = JSON.parse(body)
+                        } catch (err) {
+                            // ignore
                         }
-                    } catch (err) {
-                        // ignore
                     }
                     const options = {
                         headers: reqHeaders,

--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -170,10 +170,19 @@ class EditorTunnel {
                     // console.log('Making a request to:', fullUrl, 'x-access-token:', request.method, reqHeaders['x-access-token'])
                     // debug(`proxy [${request.method}] ${fullUrl}`)
                     // debug(`body ${request.body}`)
+                    let body  = request.body
+                    try {
+                        let temp = JSON.parse(body)
+                        if (typeof temp === "string") {
+                            body = temp
+                        }
+                    } catch (err) {
+                        // ignore
+                    }
                     const options = {
                         headers: reqHeaders,
                         method: request.method,
-                        body: request.body ? JSON.parse(request.body) : undefined,
+                        body: body,
                         throwErrors: false
                     }
                     if (thisTunnel.localProtocol === 'https') {


### PR DESCRIPTION

## Description

<!-- Describe your changes in detail -->
HTTP Body is JSON.stringify() before being sent down the tunnel need to JSON.parse() before forwarding on to editor

## Related Issue(s)

<!-- What issue does this PR relate to? -->
flowfuse/flowfuse#2999

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

