### PR TITLE
bug: Use $USER instead of undefined variable

### DIFF
--- a/service/raspbian-install-device-agent.sh
+++ b/service/raspbian-install-device-agent.sh
@@ -80,7 +80,7 @@ sudo npm install -g @flowforge/flowforge-device-agent
 
 # Create the working directory for the Device Agent
 sudo mkdir -p /opt/flowforge-device
-sudo chown -R $SUDO_USER /opt/flowforge-device
+sudo chown -R $USER /opt/flowforge-device
 
 # Create systemd service file for Device Agent
 echo "[Unit]
@@ -90,7 +90,7 @@ Documentation=https://flowforge.com/docs
 
 [Service]
 Type=simple
-User=$SUDO_USER
+User=$USER
 WorkingDirectory=/opt/flowforge-device
 
 Environment="NODE_OPTIONS=--max_old_space_size=512"


### PR DESCRIPTION
The script used to use `$SUDO_USER`, which was undefined. This change relies on the predefined `$USER` variable instead.

This change has been validated on my device.

## Related Issue(s)

Closes https://github.com/FlowFuse/device-agent/issues/192

Closes https://github.com/FlowFuse/device-agent/issues/187

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label