### PR TITLE
Update setup-node action

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - run: npm ci


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Bump to v3 to stop using NodeJS v12 (only to install NodeJS v16) this removes a build warning on the action.

