### PR TITLE
Move npm org

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - name: "Install jq"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -57,6 +57,7 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
           readme-filepath: ./docker/README.md
   publish_legacy:
+    needs: [publish]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -16,18 +16,10 @@ jobs:
       - uses: JS-DevTools/npm-publish@v2.2.0
         with:
           token: ${{ secrets.NPM_PUBLISH_TOKEN }}
-
   build_container:
     needs: [publish]
     runs-on: ubuntu-latest
     steps:
-      # - name: wait for npm
-      #   uses: gr2m/await-npm-package-version-action@v1
-      #   with:
-      #     package: "@flowforge/flowforge-device-agent"
-      #     version: ${{ github.event.release.tag_name }}
-      #     timeout: 300
-      #     registry: https://registry.npmjs.org
       - name: checkout
         uses: actions/checkout@v3
       - name: Docker Meta Data
@@ -47,9 +39,9 @@ jobs:
       - name: docker login
         uses: docker/login-action@v2.2.0
         with:
-          username: flowforge
+          username: flowfuse
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-      - name: Build and push FlowForge Device Agent container
+      - name: Build and push FlowFuse Device Agent container
         uses: docker/build-push-action@v4.0.0
         with:
           context: docker
@@ -60,7 +52,59 @@ jobs:
       - name: Publish README.md to Docker hub
         uses: peter-evans/dockerhub-description@v3
         with:
+          repository: flowfuse/device-agent
+          username: flowfuse
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          readme-filepath: ./docker/README.md
+  publish_legacy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - name: "Install jq"
+        run: sudo apt-get install -y jq
+      - name: "Patch module name"
+        working-directory: helm
+        run: |
+          cat package.json | jq '.name = "@flowforge/flowforge-device-agent"' > package.json-patched
+          mv package.json-patched package.json
+      - run: npm install
+      - uses: JS-DevTools/npm-publish@v2.2.0
+        with:
+          token: ${{ secrets.NPM_PUBLISH_TOKEN_FLOWFORGE }}
+      - name: Docker Meta Data
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          tags: |
+            type=semver,event=tag,pattern={{version}}
+          flavor: |
+            latest=true
+          images: |
+            flowforge/device-agent
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2.2.0
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2.6.0
+      - name: docker login
+        uses: docker/login-action@v2.2.0
+        with:
+          username: flowforge
+          password: ${{ secrets.DOCKER_HUB_PASSWORD_FLOWFORGE }}
+      - name: Build and push FlowFuse Device Agent container
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: docker
+          file: docker/Dockerfile_flowforge
+          tags: ${{ steps.meta.outputs.tags }}
+          push: true
+          platforms: linux/amd64, linux/arm64, linux/arm/v7
+      - name: Publish README.md to Docker hub
+        uses: peter-evans/dockerhub-description@v3
+        with:
           repository: flowforge/device-agent
           username: flowforge
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD_FLOWFORGE }}
           readme-filepath: ./docker/README.md

--- a/README.md
+++ b/README.md
@@ -14,28 +14,32 @@ The Device Agent can be installed on most Linux distributions, Windows, and MacO
 
 ## Installing the Device Agent
 
-The Device Agent is published to the public npm repository as [@flowforge/flowforge-device-agent](https://www.npmjs.com/package/@flowforge/flowforge-device-agent).
+The Device Agent is published to the public npm repository as [@flowfuse/device-agent](https://www.npmjs.com/package/@flowfuse/device-agent).
 
-It can be installed as a global npm module. This will ensure the agent
-command is on the path:
+It can be installed as a global npm module. This will ensure the agent command is on the path.
+
+Note: previous versions of the agent were published as `@flowforge/flowforge-device-agent`.
 
 ### Linux/MacOS
 
 ```bash
-sudo npm install -g @flowforge/flowforge-device-agent
+sudo npm install -g @flowfuse/device-agent
 ```
 
 ### Windows
 
 ```bash
-npm install -g @flowforge/flowforge-device-agent
+npm install -g @flowfuse/device-agent
 ```
 
-Or you can chose to run the Docker container. When you do, you'll need to mount
-the `device.yml` obtained when [Registering the device](#register-the-device):
+### Docker
+
+We publish a Docker container for the Device Agent as `flowfuse/device-agent` on DockerHub.
+
+When running with the container you will need to mount the `device.yml` obtained when [Registering the device](#register-the-device):
 
 ```bash
-docker run --mount /path/to/device.yml:/opt/flowforge/device.yml -p 1880:1880 flowforge/device-agent:latest
+docker run --mount /path/to/device.yml:/opt/flowfuse/device.yml -p 1880:1880 flowfuse/device-agent:latest
 ```
 
 ## Configuration
@@ -46,8 +50,11 @@ directory.
 
 ### Configuration directory
 
-By default the agent uses `/opt/flowforge-device` or `c:\opt\flowforge-device` as 
+By default the agent uses `/opt/flowfuse-device` or `c:\opt\flowfuse-device` as 
 its working directory. This can be overridden with the `-d/--dir` option.
+
+For backwards compatibility with previous versions, the agent will use `/opt/flowforge-device`
+if it is exists, unless overridden on the command-line.
 
 NOTE: The device agent will attempt to create the working directory if it is not found,
 however if an error occurs, the device agent will exit and report a startup error.
@@ -55,14 +62,14 @@ however if an error occurs, the device agent will exit and report a startup erro
 #### Linux/MacOS
 
 ```bash
-sudo mkdir /opt/flowforge-device
-sudo chown -R $USER /opt/flowforge-device
+sudo mkdir /opt/flowfuse-device
+sudo chown -R $USER /opt/flowfuse-device
 ```
 
 #### Windows (run elevated)
 
 ```bash
-mkdir c:\opt\flowforge-device
+mkdir c:\opt\flowfuse-device
 ```
 
 
@@ -127,9 +134,9 @@ to provide absolute paths to files containing the certificates/keys.
 
 ```yml
 https:
-   keyPath: /opt/flowforge-device/certs/key.pem
-   certPath: /opt/flowforge-device/certs/cert.pem
-   caPath: /opt/flowforge-device/certs/ca.pem
+   keyPath: /opt/flowfuse-device/certs/key.pem
+   certPath: /opt/flowfuse-device/certs/cert.pem
+   caPath: /opt/flowfuse-device/certs/ca.pem
 ```
 
 ##### `httpStatic` configuration
@@ -139,7 +146,7 @@ This option can be used to serve content from a local directory.
 If set to a path, the files in that directory will be served relative to `/`.
 
 ```yml
-httpStatic: /opt/flowforge-device/static-content
+httpStatic: /opt/flowfuse-device/static-content
 ```
 
 It is also possible to configure it with a list of directories and the corresponding
@@ -147,9 +154,9 @@ path they should be served from.
 
 ```yml
 httpStatic:
-  - path: /opt/flowforge-device/static-content/images
+  - path: /opt/flowfuse-device/static-content/images
     root: /images
-  - path: /opt/flowforge-device/static-content/js
+  - path: /opt/flowfuse-device/static-content/js
     root: /js
 ```
 
@@ -184,13 +191,13 @@ Extra options   | Description
 ## Running
 
 If the agent was installed as a global npm module, the command 
-`flowforge-device-agent` will be on the path.
+`flowfuse-device-agent` will be on the path.
 
 If the default working directory and config file are being used, then the agent
 can be started with:
 
 ```
-$ flowforge-device-agent
+$ flowfuse-device-agent
 ```
 
 For information about the available command-line arguments, run with `-h`:
@@ -199,7 +206,7 @@ For information about the available command-line arguments, run with `-h`:
 Options
 
   -c, --config file     Device configuration file. Default: device.yml
-  -d, --dir dir         Where the agent should store its state. Default: /opt/flowforge-device
+  -d, --dir dir         Where the agent should store its state. Default: /opt/flowfuse-device
   -i, --interval secs
   -p, --port number
   -m, --moduleCache     Use local npm module cache rather than install
@@ -232,7 +239,7 @@ set of modules.
 You can enable this mode by adding `-m` to the command line adding `moduleCache: true` 
 to the `device.yml` file. This will cause the Device Agent to load the modules from the 
 `module_cache` directory in the Device Agents Configuration directory as described above.
-By default this will be `/opt/flowforge-device/module_cache`.
+By default this will be `/opt/flowfuse-device/module_cache`.
 
 ### Creating a module cache
 

--- a/docker/Dockerfile_flowforge
+++ b/docker/Dockerfile_flowforge
@@ -4,7 +4,7 @@ ARG VERSION=latest
 
 RUN apk add --no-cache --virtual buildtools build-base linux-headers udev python3
 
-RUN mkdir /opt/flowfuse-device
+RUN mkdir /opt/flowforge-device
 RUN npm install -g @flowfuse/device-agent@${VERSION}
 
 EXPOSE 1880

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,16 +1,16 @@
-# FlowForge Device Agent
+# FlowFuse Device Agent
 
-This container can be used to start a FlowForge device. The device needs to
-be [registered on your FlowForge instance](https://flowforge.com/docs/user/devices/#register-the-device).
+This container can be used to start a FlowFuse device. The device needs to
+be [registered on your FlowFuse instance](https://flowfuse.com/docs/device-agent/register/).
 
 The YAML with configuration needs to be mounted inside the container.
 
 ```
-docker run -v /path/to/device.yml:/opt/flowforge-device/device.yml -p 1880:1880 flowforge/device-agent:latest
+docker run -v /path/to/device.yml:/opt/flowfuse-device/device.yml -p 1880:1880 flowfuse/device-agent:latest
 ```
 
 To run with verbose logging run as follows:
 
 ```
-docker run -v /path/to/device.yml:/opt/flowforge-device/device.yml -p 1880:1880 flowforge/device-agent:latest flowforge-device-agent -v
+docker run -v /path/to/device.yml:/opt/flowfuse-device/device.yml -p 1880:1880 flowfuse/device-agent:latest flowfuse-device-agent -v
 ```

--- a/index.js
+++ b/index.js
@@ -16,6 +16,18 @@ const ConfigLoader = require('./lib/config')
 const webServer = new WebServer()
 
 function main (testOptions) {
+    const pkg = require('./package.json')
+    if (pkg.name === '@flowforge/flowforge-device-agent') {
+        console.log(`
+**************************************************************************
+* The FlowFuse Device Agent is moving to '@flowfuse/device-agent' on npm *
+* and 'flowfuse/device-agent' on DockerHub. Please upgrade to the new    *
+* packages to ensure you continue to receive updates.                    *
+* See https://flowfuse.com/docs/device-agent/install/ for details        *
+**************************************************************************
+`)
+    }
+
     let options
 
     try {
@@ -27,12 +39,23 @@ function main (testOptions) {
         quit()
     }
     if (options.version) {
-        console.log(require('./package.json').version)
+        console.log(pkg.version)
         quit()
     }
     if (options.help) {
         console.log(require('./lib/cli/usage').usage())
         quit()
+    }
+
+    if (options.dir === '') {
+        // No dir has been explicitly set, so we need to set the default.
+        // 1. Use `/opt/flowforge-device` if it exists
+        // 2. Otherwise use `/opt/flowfuse-device`
+        if (fs.existsSync('/opt/flowforge-device')) {
+            options.dir = '/opt/flowforge-device'
+        } else {
+            options.dir = '/opt/flowfuse-device'
+        }
     }
 
     if (!path.isAbsolute(options.dir)) {
@@ -48,7 +71,7 @@ function main (testOptions) {
             }
         } catch (err) {
             const quitMsg = `Cannot create dir '${options.dir}'.
-                Please ensure the parent directory is writable, or set a different path with -d`
+Please ensure the parent directory is writable, or set a different path with -d`
             quit(quitMsg, 20) // Exit Code 20 - Invalid dir
             // REF: https://slg.ddnss.de/list-of-common-exit-codes-for-gnu-linux/
             return

--- a/lib/cli/args.js
+++ b/lib/cli/args.js
@@ -11,10 +11,12 @@ module.exports = [
     },
     {
         name: 'dir',
-        description: 'Where the agent should store its state. Default: {underline /opt/flowforge-device}',
+        description: 'Where the agent should store its state. Default: {underline /opt/flowfuse-device}',
         alias: 'd',
         type: String,
-        defaultValue: '/opt/flowforge-device',
+        // Set default to blank so we can distinguish between it being left as
+        // default, and a user setting it explicitly via -d
+        defaultValue: '',
         typeLabel: '{underline dir}',
         group: 'main'
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "@flowforge/flowforge-device-agent",
+    "name": "@flowfuse/device-agent",
     "version": "1.13.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "@flowforge/flowforge-device-agent",
+            "name": "@flowfuse/device-agent",
             "version": "1.13.0",
             "license": "Apache-2.0",
             "dependencies": {
@@ -19,7 +19,8 @@
                 "yaml": "^2.1.1"
             },
             "bin": {
-                "flowforge-device-agent": "index.js"
+                "flowforge-device-agent": "index.js",
+                "flowfuse-device-agent": "index.js"
             },
             "devDependencies": {
                 "aedes": "^0.49.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@flowfuse/device-agent",
-    "version": "1.13.0",
+    "version": "1.13.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@flowfuse/device-agent",
-            "version": "1.13.0",
+            "version": "1.13.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@flowforge/nr-theme": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@flowforge/flowforge-device-agent",
+    "name": "@flowfuse/device-agent",
     "version": "1.13.1",
     "description": "An Edge Agent for running Node-RED instances deployed from the FlowFuse Platform",
     "exports": {
@@ -23,7 +23,8 @@
         "test:frontend": "mocha test/unit/frontend/**/*.spec.js"
     },
     "bin": {
-        "flowforge-device-agent": "./index.js"
+        "flowforge-device-agent": "./index.js",
+        "flowfuse-device-agent": "./index.js"
     },
     "keywords": [
         "flowfuse",


### PR DESCRIPTION
## Description

This updates the Device Agent to the new `@flowfuse/device-agent` npm package and `flowfuse/device-agent` dockerhub image.

As part of this migration it also:

 - Updates the readme to cover the new locations
 - Updates the default data directory to `/opt/flowfuse-device/` - however it will use `/top/flowforge-device` if it exists and nothing else has been specified
 - Updates the workflow to cross-publish to the existing npm package and container images. This required a dedicated Dockerfile to ensure the proper config directory still exists for the 'legacy' container.
 - Adds a startup log message if found to be installed using the old npm package name


The full set of workflow changes are untested - we cannot test it without doing a full release. So please give the workflow changes a particularly close review.

Before we do the first release once merged, we need to update some repo-level secrets:

 - `NPM_PUBLISH_TOKEN_FLOWFORGE` - the token for publishing to old npm org
 - `NPM_PUBLISH_TOKEN` - the token for publishing to the new org
 - `DOCKER_HUB_PASSWORD_FLOWFORGE` - the password for the old dockerhub account
 - `DOCKER_HUB_PASSWORD` - the password for the new dockerhub account