### PR TITLE
Bump for 1.13.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+#### 1.13.2: Release
+
+ - Update logo to fuse branding (#199) @knolleary
+ - Rebranding in the service file and installer (#198) @knolleary
+ - Move npm org (#197) @knolleary
+ - Update setup-node action (#196) @hardillb
+ 
 #### 1.13.1: Release
 
  - Ensure that tunneled payloads are parsed (#189) @hardillb

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@flowfuse/device-agent",
-    "version": "1.13.1",
+    "version": "1.13.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@flowfuse/device-agent",
-            "version": "1.13.1",
+            "version": "1.13.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@flowforge/nr-theme": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flowfuse/device-agent",
-    "version": "1.13.1",
+    "version": "1.13.2",
     "description": "An Edge Agent for running Node-RED instances deployed from the FlowFuse Platform",
     "exports": {
         "./libraryPlugin": "./lib/plugins/libraryPlugin.js"


### PR DESCRIPTION
## Description

Update to 1.13.2.

This will be the first release cross-published to both old and new npm/dockerhub orgs