### PR TITLE
Include project nodes for app assigned devices

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -3,6 +3,7 @@ const { existsSync } = require('fs')
 const fs = require('fs/promises')
 const path = require('path')
 const { info, debug, warn, NRlog } = require('./logging/log')
+const utils = require('./utils')
 
 const MIN_RESTART_TIME = 10000 // 10 seconds
 const MAX_RESTART_COUNT = 5
@@ -194,13 +195,12 @@ class Launcher {
                 path.join(__dirname, 'plugins', 'node_modules', '@flowforge', 'flowforge-library-plugin').replace(/\\/g, '/')
             ]
             // Check to see if we're in the dev-env - if so, we need to set a different
-            // path to the `@flowforge/nr-project-nodes` for development purposes
-            const devEnvPath = path.join(__dirname, '..', '..', '..', 'packages', 'nr-project-nodes').replace(/\\/g, '/')
-            if (existsSync(devEnvPath)) {
-                settings.nodesDir.push(devEnvPath)
-            } else {
-                settings.nodesDir.push(path.join(__dirname, '..', 'node_modules', '@flowfuse', 'nr-project-nodes').replace(/\\/g, '/'))
+            // path to the project-nodes for development purposes
+            let projectNodesPackage = '@flowfuse/nr-project-nodes' // runtime default
+            if (utils.isDevEnv()) {
+                projectNodesPackage = 'nr-project-nodes'
             }
+            settings.nodesDir.push(utils.getPackagePath(projectNodesPackage))
             const sharedLibraryConfig = {
                 id: 'flowfuse-team-library',
                 type: 'flowfuse-team-library',

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -187,11 +187,20 @@ class Launcher {
             }
         }
 
-        // if licensed, add shared library config
+        // if licensed, add shared library config and other EE artifacts
         if (this.config.licensed) {
+            // setup nodeDir to include the path to additional nodes and plugins
             settings.nodesDir = [
-                path.join(__dirname, 'plugins', 'node_modules', '@flowforge', 'flowforge-library-plugin')
+                path.join(__dirname, 'plugins', 'node_modules', '@flowforge', 'flowforge-library-plugin').replace(/\\/g, '/')
             ]
+            // Check to see if we're in the dev-env - if so, we need to set a different
+            // path to the `@flowforge/nr-project-nodes` for development purposes
+            const devEnvPath = path.join(__dirname, '..', '..', '..', 'packages', 'nr-project-nodes').replace(/\\/g, '/')
+            if (existsSync(devEnvPath)) {
+                settings.nodePaths.push(devEnvPath)
+            } else {
+                settings.nodesDir.push(path.join(__dirname, '..', 'node_modules', '@flowfuse', 'nr-project-nodes').replace(/\\/g, '/'))
+            }
             const sharedLibraryConfig = {
                 id: 'flowfuse-team-library',
                 type: 'flowfuse-team-library',

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -197,7 +197,7 @@ class Launcher {
             // path to the `@flowforge/nr-project-nodes` for development purposes
             const devEnvPath = path.join(__dirname, '..', '..', '..', 'packages', 'nr-project-nodes').replace(/\\/g, '/')
             if (existsSync(devEnvPath)) {
-                settings.nodePaths.push(devEnvPath)
+                settings.nodesDir.push(devEnvPath)
             } else {
                 settings.nodesDir.push(path.join(__dirname, '..', 'node_modules', '@flowfuse', 'nr-project-nodes').replace(/\\/g, '/'))
             }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,8 +1,13 @@
+const path = require('path')
+const existsSync = require('fs').existsSync
+
 module.exports = {
     compareNodeRedData,
     compareObjects,
     isObject,
-    hasProperty
+    hasProperty,
+    isDevEnv,
+    getPackagePath
 }
 
 /**
@@ -76,4 +81,55 @@ function isObject (object) {
  */
 function hasProperty (object, property) {
     return !!(object && Object.prototype.hasOwnProperty.call(object, property))
+}
+
+const devPackages = path.join(__dirname, '..', '..', '..', 'packages')
+const runtimePackages = path.join(__dirname, '..', 'node_modules')
+
+/**
+ * Test if the runtime is running in a development environment.
+ * Development environment is defined as:
+ * * `NODE_ENV` is set to 'development'
+ * - OR
+ * * 'packages' directory exists AND another "known" package exists (/packages/nr-project-nodes)
+ * @returns {boolean} true if the runtime is running in a development environment
+ */
+function isDevEnv () {
+    // if NODE_ENV is set, use that
+    if (process.env.NODE_ENV) {
+        return process.env.NODE_ENV === 'development'
+    }
+    const devEnvTestPath = path.join(devPackages, 'nr-project-nodes').replace(/\\/g, '/')
+    if (existsSync(devEnvTestPath)) {
+        return true
+    }
+    return false
+}
+
+/**
+ * Get the full path to a package.
+ *
+ * When running in a development environment, the path to the package in the dev-env is returned.
+ *
+ * When running in a runtime environment, the path to the package in the device-agent node_modules is returned.
+ * @example
+ * // process.env.NODE_ENV = 'development'
+ * getPackagePath('nr-project-nodes')
+ * // returns '/path/to/dev-env/packages/nr-project-nodes'
+ * @example
+ * // process.env.NODE_ENV = '' && 'nr-project-nodes' exists in `dev-env/packages`
+ * getPackagePath('nr-project-nodes')
+ * // returns '/path/to/dev-env/packages/nr-project-nodes'
+ * @example
+ * // process.env.NODE_ENV = 'production' || 'nr-project-nodes' does not exist in `dev-env/packages`
+ * getPackagePath('@flowfuse/nr-project-nodes')
+ * // returns '/path/to/device-agent/node_modules/@flowfuse/nr-project-nodes'
+ * @param  {...string} packageName Name of the package to get the path for
+ * @returns {string} The full path to the package
+ */
+function getPackagePath (...packageName) {
+    if (isDevEnv()) {
+        return path.join(devPackages, ...packageName).replace(/\\/g, '/')
+    }
+    return path.join(runtimePackages, ...packageName).replace(/\\/g, '/')
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@flowforge/nr-theme": "^1.8.0",
+                "@flowfuse/nr-project-nodes": "0.5.0",
                 "command-line-args": "^5.2.1",
                 "command-line-usage": "^6.1.3",
                 "got": "^11.8.6",
@@ -99,6 +100,18 @@
             "integrity": "sha512-p755Fa4hbUEEsP77Ud13F34/ANBC7sWLySBLMPPUTD0GbalcYdLKzHVkrdx3DRIZG7+kBTMxIa52U5EfeGWvtQ==",
             "engines": {
                 "node": ">=14.x"
+            }
+        },
+        "node_modules/@flowfuse/nr-project-nodes": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@flowfuse/nr-project-nodes/-/nr-project-nodes-0.5.0.tgz",
+            "integrity": "sha512-F9j/b7T2R4tl2Rc5w7g/L984OAyDrEeGYkKEXItzKeRP2OGothyG3yfJYj4DcXL6ehCTeDlBY0O8ifpGnGQV1g==",
+            "dependencies": {
+                "got": "^11.8.6",
+                "mqtt": "^4.3.7"
+            },
+            "engines": {
+                "node": ">=16.x"
             }
         },
         "node_modules/@humanwhocodes/config-array": {
@@ -4405,6 +4418,15 @@
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/@flowforge/nr-theme/-/nr-theme-1.8.0.tgz",
             "integrity": "sha512-p755Fa4hbUEEsP77Ud13F34/ANBC7sWLySBLMPPUTD0GbalcYdLKzHVkrdx3DRIZG7+kBTMxIa52U5EfeGWvtQ=="
+        },
+        "@flowfuse/nr-project-nodes": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@flowfuse/nr-project-nodes/-/nr-project-nodes-0.5.0.tgz",
+            "integrity": "sha512-F9j/b7T2R4tl2Rc5w7g/L984OAyDrEeGYkKEXItzKeRP2OGothyG3yfJYj4DcXL6ehCTeDlBY0O8ifpGnGQV1g==",
+            "requires": {
+                "got": "^11.8.6",
+                "mqtt": "^4.3.7"
+            }
         },
         "@humanwhocodes/config-array": {
             "version": "0.11.10",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@flowforge/nr-theme": "^1.8.0",
+        "@flowfuse/nr-project-nodes": "0.5.0",
         "command-line-args": "^5.2.1",
         "command-line-usage": "^6.1.3",
         "got": "^11.8.6",

--- a/test/unit/lib/util_spec.js
+++ b/test/unit/lib/util_spec.js
@@ -1,5 +1,6 @@
 const should = require('should') // eslint-disable-line
 const utils = require('../../../lib/utils.js')
+const path = require('path')
 
 /*
     Ensure utils used throughout agent are tested
@@ -101,6 +102,30 @@ describe('utils', function () {
             utils.compareNodeRedData({ modules: { 'node-red': 'latest' } }, { modules: {} }).should.be.false()
             utils.compareNodeRedData({ modules: { 'node-red': 'latest' } }, { modules: null }).should.be.false()
             utils.compareNodeRedData({ modules: { 'node-red': 'latest' } }, { modules: undefined }).should.be.false()
+        })
+    })
+    describe('getPackagePath', function () {
+        const devPackages = path.join(__dirname, '..', '..', '..', '..', '..', 'packages')
+        const runtimePackages = path.join(__dirname, '..', '..', '..', 'node_modules')
+        describe('developer environment', function () {
+            beforeEach(function () {
+                process.env.NODE_ENV = 'development' // simulate dev environment
+            })
+            it('should return path of the specified packageName in the dev-env path', function () {
+                const pkgPath = utils.getPackagePath('nr-project-nodes')
+                pkgPath.should.be.a.String()
+                pkgPath.should.eql(path.join(devPackages, 'nr-project-nodes').replace(/\\/g, '/'))
+            })
+        })
+        describe('runtime environment', function () {
+            beforeEach(function () {
+                process.env.NODE_ENV = 'production' // simulate runtime environment
+            })
+            it('should return path of the specified packageName in the device-agent node_modules', function () {
+                const pkgPath = utils.getPackagePath('@flowfuse/nr-project-nodes')
+                pkgPath.should.be.a.String()
+                pkgPath.should.eql(path.join(runtimePackages, '@flowfuse', 'nr-project-nodes').replace(/\\/g, '/'))
+            })
         })
     })
 })


### PR DESCRIPTION
## Description

This pull request adds project nodes for app assigned devices. The `@flowfuse/nr-project-nodes` package has been added to the `package.json` file, and the `Launcher` class has been updated to include the path to project nodes. NOTE, the `settings.nodesDir` (used to provide access to the project nodes for Node-RED) is conditionally added based on the env being EE and will include a different path to the `@flowfuse/nr-project-nodes` package in the dev-env when detected.



This pull request addresses the following commits:

- [Include project nodes for app assigned device](https://github.com/FlowFuse/device-agent/commit/fa02e707e795995db0f68e67badfe8312a7f61f1)
- [Fix nodesDir path in launcher.js](https://github.com/FlowFuse/device-agent/commit/86d1ada1a82c51c50bb5516a43b517cb999cdde2)
- [Refactor package path handling to support testing](https://github.com/FlowFuse/device-agent/commit/4d2f7d639f599869b468b5729cb1e151707aa7e5)

## Related Issue(s)

https://github.com/FlowFuse/flowfuse/issues/3018

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

