### PR TITLE
Add Balena option to deploy Device Agent

### DIFF
--- a/balena/Dockerfile.template
+++ b/balena/Dockerfile.template
@@ -1,0 +1,11 @@
+FROM balenalib/%%BALENA_MACHINE_NAME%%-alpine-node
+
+RUN mkdir /opt/flowfuse-device
+RUN npm install -g @flowfuse/device-agent
+
+COPY entrypoint.sh /usr/src/entrypoint.sh
+
+ENTRYPOINT ["/usr/src/entrypoint.sh"]
+
+CMD ["flowfuse-device-agent"]
+

--- a/balena/README.md
+++ b/balena/README.md
@@ -1,6 +1,6 @@
 # Deploy Flowfuse Device Agent with Balena
 
-[![balena deploy button](https://www.balena.io/deploy.svg)](https://dashboard.balena-cloud.com/deploy?repoUrl=https://github.com/flowfuse/device-agent&https://github.com/flowfuse/device-agent/balena/balena.yml)
+[![balena deploy button](https://www.balena.io/deploy.svg)](https://dashboard.balena-cloud.com/deploy?repoUrl=https://github.com/flowfuse/device-agent&https://raw.githubusercontent.com/flowfuse/device-agent/master/balena/balena.yml)
 
 The documentation for the FlowFuse Device Agent can be found [here](https://flowfuse.com/docs/device-agent/introduction/)
 

--- a/balena/README.md
+++ b/balena/README.md
@@ -1,0 +1,25 @@
+# Deploy Flowfuse Device Agent with Balena
+
+[![balena deploy button](https://www.balena.io/deploy.svg)](https://dashboard.balena-cloud.com/deploy?repoUrl=https://github.com/flowfuse/device-agent&https://github.com/flowfuse/device-agent/balena/balena.yml)
+
+The documentation for the FlowFuse Device Agent can be found [here](https://flowfuse.com/docs/device-agent/introduction/)
+
+## Configure
+
+The FlowFuse Device Agent can be configured in 3 ways:
+
+ 1. If started with no configuration file the Device Agent will start a Web Server that will allow a `device.yml` file to be uploaded locally to the Device. The `device.yml` is provided by the FlowFuse platform when the device is created.
+ 2. A `device.yml` file provided when the Device is created in the FlowFuse platform. This file can be injected into the Belena device using the `FF_DEVICE_YML` environment variable (see below)
+ 3. A group of Devices can be give a `device.yml` that contains a Provisionig Token. This will cause the Device to connect to the FlowFuse platform and register a new device, it will then download it's own unique `device.yml` file. The Provisioning token can be passed to the Belena device using the `FF_DEVICE_YML` environment variable (see below). Provisioning tokens are created on the Team -> Settings page, under the Device's tab.
+    When using a Provisioning Token the Belena Device name will match the FlowFuse Device name.
+
+### Passing configuration via Environment variable
+
+Download either a Device configuration file or a Provisioning token and then Base64 encode this (with no line breaks) using the following command:
+
+```
+base64 -w 0 device.yml
+```
+
+In the Balena Fleet config set a Variable called `FF_DEVICE_YML` to the output of the base64 command, this can either be on a per device basis for option 2 or fleet wide variable for option 3.
+

--- a/balena/balena.yml
+++ b/balena/balena.yml
@@ -7,6 +7,10 @@ assets:
     type: blob.asset
     data:
       url: 'https://github.com/flowfuse/device-agent'
+  logo:
+    type: blob.asset
+    data:
+      url: https://website-data.s3.eu-west-1.amazonaws.com/ff-logo--wordmark--light.png
 data:
   defaultDeviceType: raspberry-pi
   supportedDeviceTypes:

--- a/balena/balena.yml
+++ b/balena/balena.yml
@@ -10,7 +10,7 @@ assets:
   logo:
     type: blob.asset
     data:
-      url: https://website-data.s3.eu-west-1.amazonaws.com/ff-logo--wordmark--light.png
+      url: 'https://website-data.s3.eu-west-1.amazonaws.com/ff-logo--wordmark--light.png'
 data:
   defaultDeviceType: raspberry-pi
   supportedDeviceTypes:

--- a/balena/balena.yml
+++ b/balena/balena.yml
@@ -1,0 +1,21 @@
+name: flowfuseDeviceAgent
+type: sw.application
+description: >-
+  Deploy the FlowFuse Device agent using Balena
+assets:
+  repository:
+    type: blob.asset
+    data:
+      url: 'https://github.com/flowfuse/device-agent'
+data:
+  defaultDeviceType: raspberry-pi
+  supportedDeviceTypes:
+    - raspberry-pi
+    - raspberry-pi2
+    - raspberrypi3-64
+    - raspberrypi4-64
+    - raspberrypi5
+    - intel-nuc
+    - jetson-nano
+    - jetson-nano-emmc
+version: 1.0.0

--- a/balena/docker-compose.yml
+++ b/balena/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "2.1"
+
+services:
+  devagent:
+    build:
+      context: .
+    restart: always
+    network_mode: host
+    privileged: true
+    ports:
+      - "1880:1880"
+    volumes:
+      - ff-device:/opt/flowfuse-device
+
+volumes:
+  ff-device:

--- a/balena/entrypoint.sh
+++ b/balena/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+hostname $BALENA_DEVICE_NAME_AT_INIT
+
+if  [ ! -z "$FF_DEVICE_YML" ]; then
+  echo "FF_DEVICE_YML env var found"
+  echo "$FF_DEVICE_YML"
+  cat /opt/flowfuse-device/device.yml
+  if [ ! -f /opt/flowfuse-device/device.yml ]; then
+    echo "Writing file"
+    echo $FF_DEVICE_YML | base64 -d > /opt/flowfuse-device/device.yml
+    cat /opt/flowfuse-device/device.yml
+  else
+    echo "Existing device.yml found"
+    cat /opt/flowfuse-device/device.yml
+  fi
+else
+  echo "No device.yml env var provided"
+fi
+
+echo $@
+
+exec "$@"


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Add Balena option to deploy Device Agent

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

