### PR TITLE
Enable WebSocket Affinity in the device agent

### DIFF
--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -62,7 +62,7 @@ class EditorTunnel {
             'x-access-token': this.options.token
         }
         if (this.affinity) {
-            headers.cookie = `INGRESSCOOKIE=${this.affinity}`
+            headers.cookie = `FFSESSION=${this.affinity}`
         }
         const socket = newWsConnection(forgeWSEndpoint, {
             headers
@@ -72,7 +72,7 @@ class EditorTunnel {
                 const cookies = evt.headers['set-cookie']
                 cookies.forEach(cookie => {
                     const parts = cookie.split(';')[0].split(['='])
-                    if (parts === 'INGRESSCOOKIE') {
+                    if (parts === 'FFSESSION') {
                         this.affinity = parts[1]
                     }
                 })

--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -22,6 +22,7 @@ class EditorTunnel {
         this.port = config.port
         this.config = config
         this.options = options || {}
+        this.affinity = undefined
 
         // How long to wait before attempting to reconnect. Start at 500ms - back
         // off if connect fails
@@ -57,9 +58,24 @@ class EditorTunnel {
         info(`Connecting editor tunnel to ${forgeWSEndpoint}`)
 
         // * Enable Device Editor (Step 8) - (device->forge:WS) Initiate WS connection (with token)
+        const headers = {
+            'x-access-token': this.options.token
+        }
+        if (this.affinity) {
+            headers.cookie = `INGRESSCOOKIE=${this.affinity}`
+        }
         const socket = newWsConnection(forgeWSEndpoint, {
-            headers: {
-                'x-access-token': this.options.token
+            headers
+        })
+        socket.on('upgrade', (evt) => {
+            if (evt.headers && evt.headers['set-cookie']) {
+                const cookies = evt.headers['set-cookie']
+                cookies.forEach(cookie => {
+                    const parts = cookie.split(';')[0].split(['='])
+                    if (parts === 'INGRESSCOOKIE') {
+                        this.affinity = parts[1]
+                    }
+                })
             }
         })
         socket.onopen = (evt) => {

--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -70,12 +70,19 @@ class EditorTunnel {
         socket.on('upgrade', (evt) => {
             if (evt.headers && evt.headers['set-cookie']) {
                 const cookies = evt.headers['set-cookie']
-                cookies.forEach(cookie => {
-                    const parts = cookie.split(';')[0].split(['='])
+                if (Array.isArray(cookies)) {
+                    cookies.forEach(cookie => {
+                        const parts = cookie.split(';')[0].split(['='])
+                        if (parts === 'FFSESSION') {
+                            this.affinity = parts[1]
+                        }
+                    })
+                } else {
+                    const parts = cookies.split(';')[0].split(['='])
                     if (parts === 'FFSESSION') {
                         this.affinity = parts[1]
                     }
-                })
+                }
             }
         })
         socket.onopen = (evt) => {

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -115,7 +115,7 @@ class MQTTClient {
                     // * Enable Device Editor (Step 7) - (device) Begin the device tunnel connect process
                     const result = await this.tunnel.connect()
                     // * Enable Device Editor (Step 10) - (device->forge:MQTT) Send a response to the platform
-                    this.sendCommandResponse(msg, { connected: result, token: msg?.payload?.token })
+                    this.sendCommandResponse(msg, { connected: result, token: msg?.payload?.token, affinity: this.tunnel.affinity })
                     this.sendStatus()
                     return
                 } else if (msg.command === 'stopEditor') {


### PR DESCRIPTION
part of FlowFuse/flowfuse#2514

## Description

<!-- Describe your changes in detail -->
As part of work to enable horizontal scaling of the Forge App, this allows the Device agent to use a cookie to bind to a specific instance (using Nginx Affinity mapping to start with).

Reuses the affinity cookie if present, shares the affinity cookie with the forge platform if available.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
FlowFuse/flowfuse#2514

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

