### PR TITLE
Fix Docker path to the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ We publish a Docker container for the Device Agent as `flowfuse/device-agent` on
 When running with the container you will need to mount the `device.yml` obtained when [Registering the device](#register-the-device):
 
 ```bash
-docker run --mount type=bind,src=/path/to/device.yml,target=/opt/flowfuse/device.yml -p 1880:1880 flowfuse/device-agent:latest
+docker run --mount type=bind,src=/path/to/device.yml,target=/opt/flowfuse-device/device.yml -p 1880:1880 flowfuse/device-agent:latest
 ```
 
 ## Configuration


### PR DESCRIPTION
## Description

The path to the config file is incorrect.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

