### PR TITLE
Permit Device Agent to automatically re-establish Editor Tunnel after a restart

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -31,6 +31,7 @@ class Agent {
         // Track the local state of the agent. Start in 'unknown' state so
         // that the first MQTT check-in will trigger a response
         this.currentState = 'unknown'
+        this.editorToken = null
         // ensure licensed property is present (default to null)
         if (utils.hasProperty(this.config, 'licensed') === false) {
             this.config.licensed = null
@@ -50,6 +51,7 @@ class Agent {
                     }
                     this.currentProject = null
                     this.currentApplication = null
+                    this.editorToken = null
                 } else {
                     // New format
                     this.currentApplication = config.project ? null : (config.application || null)
@@ -58,6 +60,7 @@ class Agent {
                     this.currentSettings = config.settings || null
                     this.currentMode = config.mode || 'autonomous'
                     this.config.licensed = config.licensed || null
+                    this.editorToken = config.editorToken || null
                 }
                 this.printAgentStatus()
             } catch (err) {
@@ -103,7 +106,8 @@ class Agent {
             snapshot: this.currentSnapshot,
             settings: this.currentSettings,
             mode: this.currentMode,
-            licensed: this.config.licensed
+            licensed: this.config.licensed,
+            editorToken: this.editorToken
         }))
     }
 
@@ -249,6 +253,7 @@ class Agent {
                     await this.saveProject()
                 } else {
                     // exiting developer mode
+                    this.editorToken = null // clear the discarded token
                     let _launcher = this.launcher
                     if (!_launcher) {
                         // create a temporary launcher to read the current snapshot on disk
@@ -345,7 +350,7 @@ class Agent {
         }
 
         /** A flag to inhibit updates if we are in developer mode */
-        const inhibitUpdates = this.currentMode === 'developer'
+        const developerMode = this.currentMode === 'developer'
 
         /** A flag to indicate execution should skip to the update step */
         const skipToUpdate = newState?.reloadSnapshot === true
@@ -353,18 +358,19 @@ class Agent {
         if (newState === null) {
             // The agent should not be running (bad credentials/device details)
             // Wipe the local configuration
-            if (inhibitUpdates === false) {
+            if (developerMode === false) {
                 this.stop()
                 this.currentSnapshot = null
                 this.currentApplication = null
                 this.currentProject = null
                 this.currentSettings = null
                 this.currentMode = null
+                this.editorToken = null
                 await this.saveProject()
                 this.currentState = 'stopped'
                 this.updating = false
             }
-        } else if (!skipToUpdate && inhibitUpdates === false && newState.application === null && this.currentOwnerType === 'application') {
+        } else if (!skipToUpdate && developerMode === false && newState.application === null && this.currentOwnerType === 'application') {
             if (this.currentApplication) {
                 debug('Removed from application')
             }
@@ -392,7 +398,7 @@ class Agent {
             await this.saveProject()
             this.currentState = 'stopped'
             this.updating = false
-        } else if (!skipToUpdate && inhibitUpdates === false && newState.project === null && this.currentOwnerType === 'project') {
+        } else if (!skipToUpdate && developerMode === false && newState.project === null && this.currentOwnerType === 'project') {
             if (this.currentProject) {
                 debug('Removed from project')
             }
@@ -420,7 +426,7 @@ class Agent {
             await this.saveProject()
             this.currentState = 'stopped'
             this.updating = false
-        } else if (!skipToUpdate && inhibitUpdates === false && newState.snapshot === null) {
+        } else if (!skipToUpdate && developerMode === false && newState.snapshot === null) {
             // Snapshot removed, but project/application still set
             if (this.currentSnapshot) {
                 debug('Active snapshot removed')
@@ -472,13 +478,13 @@ class Agent {
             const snapShotUpdatePending = !!(!this.currentSnapshot && newState.snapshot)
             const projectUpdatePending = !!(newState.ownerType === 'project' && !this.currentProject && newState.project)
             const applicationUpdatePending = !!(newState.ownerType === 'application' && !this.currentApplication && newState.application)
-            if (unknownOrStopped && inhibitUpdates && snapShotUpdatePending && (projectUpdatePending || applicationUpdatePending)) {
+            if (unknownOrStopped && developerMode && snapShotUpdatePending && (projectUpdatePending || applicationUpdatePending)) {
                 info('Developer Mode: no flows found - updating to latest snapshot')
                 this.currentProject = newState.project
                 this.currentApplication = newState.application
                 updateSnapshot = true
                 updateSettings = true
-            } else if (inhibitUpdates === false) {
+            } else if (developerMode === false) {
                 if (utils.hasProperty(newState, 'project') && (!this.currentSnapshot || newState.project !== this.currentProject)) {
                     info('New instance assigned')
                     this.currentApplication = null
@@ -528,6 +534,9 @@ class Agent {
                     if (this.mqttClient) {
                         this.mqttClient.setProject(this.currentProject)
                         this.mqttClient.setApplication(this.currentApplication)
+                        if (developerMode && this.editorToken) {
+                            this.mqttClient.startTunnel(this.editorToken)
+                        }
                     }
                     this.checkIn(2)
                     this.currentState = 'stopped'
@@ -573,6 +582,9 @@ class Agent {
                         if (this.mqttClient) {
                             this.mqttClient.setProject(this.currentProject)
                             this.mqttClient.setApplication(this.currentApplication)
+                            if (developerMode && this.editorToken) {
+                                this.mqttClient.startTunnel(this.editorToken)
+                            }
                         }
                         this.checkIn(2)
                     } catch (err) {
@@ -675,6 +687,14 @@ class Agent {
                 debug(err)
             }
         })
+    }
+
+    async saveEditorToken (token) {
+        const changed = this.editorToken !== token
+        this.editorToken = token
+        if (changed) {
+            await this.saveProject()
+        }
     }
 }
 

--- a/lib/logging/log.js
+++ b/lib/logging/log.js
@@ -24,6 +24,10 @@ function NRlog (msg) {
     } catch (eee) {
         jsMsg = { ts: Date.now(), level: '', msg }
     }
+    if (!Object.hasOwn(jsMsg, 'ts') && !Object.hasOwn(jsMsg, 'level')) {
+        // not a NR log message
+        jsMsg = { ts: Date.now(), level: '', msg }
+    }
     const date = new Date(jsMsg.ts)
     if (typeof jsMsg.msg !== 'string') {
         jsMsg.msg = JSON.stringify(jsMsg.msg)

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -100,23 +100,7 @@ class MQTTClient {
                     this.logEnabled = false
                     return
                 } else if (msg.command === 'startEditor') {
-                    info('Enabling remote editor access')
-                    if (this.tunnel) {
-                        this.tunnel.close()
-                        this.tunnel = null
-                    }
-                    if (!this.agent.launcher) {
-                        info('No running Node-RED instance, not starting editor')
-                        this.sendCommandResponse(msg, { connected: false, token: msg?.payload?.token, error: 'noNRRunning' })
-                        return
-                    }
-                    // * Enable Device Editor (Step 6) - (forge:MQTT->device) Create the tunnel on the device
-                    this.tunnel = EditorTunnel.create(this.config, { token: msg?.payload?.token })
-                    // * Enable Device Editor (Step 7) - (device) Begin the device tunnel connect process
-                    const result = await this.tunnel.connect()
-                    // * Enable Device Editor (Step 10) - (device->forge:MQTT) Send a response to the platform
-                    this.sendCommandResponse(msg, { connected: result, token: msg?.payload?.token })
-                    this.sendStatus()
+                    await this.startTunnel(msg.payload?.token, msg)
                     return
                 } else if (msg.command === 'stopEditor') {
                     if (this.tunnel) {
@@ -280,6 +264,47 @@ class MQTTClient {
                 warn(`Error sending response to command ${command}: ${err}`)
             }
         })
+    }
+
+    async startTunnel (token, msg) {
+        info('Enabling remote editor access')
+        try {
+            if (this.tunnel) {
+                this.tunnel.close()
+                this.tunnel = null
+            }
+            if (!this.agent.launcher) {
+                info('No running Node-RED instance, not starting editor')
+                if (msg) {
+                    this.sendCommandResponse(msg, { connected: false, token, error: 'noNRRunning' })
+                }
+                return
+            }
+
+            // * Enable Device Editor (Step 6) - (forge:MQTT->device) Create the tunnel on the device
+            this.tunnel = EditorTunnel.create(this.config, { token })
+
+            // * Enable Device Editor (Step 7) - (device) Begin the device tunnel connect process
+            const result = await this.tunnel.connect()
+
+            // store the token for later use (i.e. device agent is restarted)
+            await this.saveEditorToken(result ? token : null)
+
+            if (msg) {
+                // * Enable Device Editor (Step 10) - (device->forge:MQTT) Send a response to the platform
+                this.sendCommandResponse(msg, { connected: result, token })
+            }
+        } catch (err) {
+            warn(`Error starting editor tunnel: ${err}`)
+            if (msg) {
+                this.sendCommandResponse(msg, { connected: false, token, error: err.toString() })
+            }
+        }
+        this.sendStatus()
+    }
+
+    async saveEditorToken (token) {
+        await this.agent?.saveEditorToken(token)
     }
 }
 

--- a/test/unit/lib/mqtt_spec.js
+++ b/test/unit/lib/mqtt_spec.js
@@ -28,7 +28,8 @@ function createAgent (opts) {
     opts.state = opts.state || 'stopped'
     const newAgent = function () {
         this.updating = false
-        this.currentMode = opts.currentMode
+        this.currentMode = opts.currentMode || null
+        this.editorToken = opts.editorToken
         this.currentSnapshot = opts.currentSnapshot
         this.currentProject = opts.currentProject
         this.currentSettings = opts.currentSettings
@@ -39,6 +40,7 @@ function createAgent (opts) {
         const agent = this
         return {
             currentMode: agent.currentMode,
+            editorToken: agent.editorToken,
             currentSnapshot: agent.currentSnapshot,
             currentProject: agent.currentProject,
             currentSettings: agent.currentSettings,
@@ -48,7 +50,8 @@ function createAgent (opts) {
             }),
             getCurrentFlows: sinon.fake.returns(agent.flows),
             getCurrentCredentials: sinon.fake.returns(agent.credentials),
-            getCurrentPackage: sinon.fake.returns(agent.package)
+            getCurrentPackage: sinon.fake.returns(agent.package),
+            saveEditorToken: sinon.fake()
         }
     }
     return newAgent()
@@ -60,7 +63,7 @@ describe('MQTT Comms', function () {
     /** @type {import('aedes-server-factory').Server} MQTT WS */ let httpServer
     /** @type {Aedes} MQTT Broker */ let aedes = null
     /** @type {MQTT.MqttClient} MQTT Client */ let mqtt
-    /** @type {MQTTClientComms} Agent mqttClient comms */ let mqttClient = null
+    /** @type {import('../../../lib/mqtt').MQTTClient} Agent mqttClient comms */ let mqttClient = null
     let currentId = 0 // incrementing id for each agent
     const sockets = {} // Maintain a hash of all connected sockets (for closing them later)
 
@@ -73,9 +76,11 @@ describe('MQTT Comms', function () {
         const snapshot = opts.snapshotId !== null ? { id: opts.snapshotId } : null
         const settings = opts.settingsId !== null ? { hash: opts.settingsId } : null
         const mode = opts.mode || 'developer'
+        const editorToken = opts.editorToken || null
 
         const agent = createAgent({
             currentMode: mode,
+            editorToken,
             currentProject: project,
             currentSettings: settings,
             currentSnapshot: snapshot,
@@ -88,7 +93,7 @@ describe('MQTT Comms', function () {
         return new MQTTClientComms(agent, {
             dir: configDir,
             forgeURL: 'http://localhost:9000',
-            brokerURL: 'ws://localhost:9001',
+            brokerURL: 'ws://localhost:9800',
             brokerUsername: `device:${team}:${device}`,
             brokerPassword: 'pass'
         })
@@ -96,7 +101,7 @@ describe('MQTT Comms', function () {
 
     before(async function () {
         aedes = new Aedes()
-        const port = 9001
+        const port = 9800
         httpServer = createServer(aedes, { ws: true })
         httpServer.listen(port, function () {
             console.log('websocket server listening on port ', port)
@@ -263,6 +268,36 @@ describe('MQTT Comms', function () {
         response.should.have.a.property('payload').and.be.an.Object()
         response.payload.should.have.a.property('connected', false)
         response.payload.should.have.a.property('token', 'token-test')
+    })
+    it('Calls save token when commanded to startEditor', async function () {
+        mqttClient.start()
+        const commandTopic = `ff/v1/${mqttClient.teamId}/d/${mqttClient.deviceId}/command`
+        const responseTopic = `ff/v1/${mqttClient.teamId}/d/${mqttClient.deviceId}/response`
+        console.log('commandTopic', commandTopic)
+        console.log('responseTopic', responseTopic)
+        mqttClient.should.have.a.property('client').and.be.an.Object()
+        mqttClient.should.have.a.property('commandTopic').and.be.a.String().and.equal(commandTopic)
+        mqttClient.should.have.a.property('responseTopic').and.be.a.String().and.equal(responseTopic)
+
+        mqttClient.agent.launcher = {} // fake a launcher so that `startTunnel` gets to the point where it saves the token
+
+        const payload = {
+            command: 'startEditor',
+            correlationData: 'correlationData-test',
+            responseTopic,
+            payload: {
+                token: 'token-test'
+            }
+        }
+        const payloadStr = JSON.stringify(payload)
+
+        // short delay to allow mqtt to connect and stack to unwind
+        await new Promise(resolve => setTimeout(resolve, 500))
+        const response = await mqttPubAndAwait(commandTopic, payloadStr, responseTopic)
+        await new Promise(resolve => setTimeout(resolve, 50))
+        response.should.have.a.property('command', 'startEditor')
+        mqttClient.agent.saveEditorToken.callCount.should.equal(1)
+        mqttClient.agent.saveEditorToken.firstCall.calledWith('token-test').should.be.true()
     })
     it('does not crash when agent.setState() throws', function (done) {
         // spy on warn()


### PR DESCRIPTION
closes #147

## Description

Stores the tunnel token and re-establishes the editor tunnel when restarting

Adds tests: 
```
Agent
  loadsProject
    loads project file with a tunnel token
  setState
    Clears editorToken when switching off developer mode
  developer mode
    editor tunnel
      reconnects tunnel in developer mode when editorToken is set
      does not attempt to reconnect tunnel if not in developer mode (even if editorToken is set)
MQTT Comms
  Calls save token when commanded to startEditor
```
Updates tests: 
```
Agent
  loadsProject
    saves project set for developer mode

```

## Related Issue(s)

#147

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

