### PR TITLE
Fix WS readystate crash

### DIFF
--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -50,6 +50,7 @@ class EditorTunnel {
 
     async connect () {
         const thisTunnel = this
+        let unexpectedPacketMonitor = 0
         if (this.socket) {
             this.close()
         }
@@ -63,6 +64,7 @@ class EditorTunnel {
             }
         })
         socket.onopen = (evt) => {
+            unexpectedPacketMonitor = 0
             info('Editor tunnel connected')
             // Reset reconnectDelay
             this.reconnectDelay = 500
@@ -156,8 +158,13 @@ class EditorTunnel {
                             wsClient.sendOrQueue(body)
                         }
                     } else {
-                        warn(`[${request.id}] Unexpected editor comms packet ${JSON.stringify(request, null, 4)}`)
-                        this.close(1006, 'Non-connect packet received for unknown connection id') // 1006 = Abnormal closure
+                        if (unexpectedPacketMonitor > 1) {
+                            unexpectedPacketMonitor = 0
+                            warn(`[${request.id}] Unexpected editor comms packet ${JSON.stringify(request, null, 4)}`)
+                            this.close(1006, 'Non-connect packet received for unknown connection id') // 1006 = Abnormal closure
+                        } else {
+                            unexpectedPacketMonitor++
+                        }
                     }
                 } else {
                     // An http related event

--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -100,7 +100,9 @@ class EditorTunnel {
                                     body: data.toString('utf-8')
                                 }
                                 // console.log(`[${request.id}] R>E`, sendData.body)
-                                this.socket?.send(JSON.stringify(sendData))
+                                if (this.socket?.readyState === WebSocket.OPEN) {
+                                    this.socket.send(JSON.stringify(sendData))
+                                }
                             })
                             // Now the local comms is connected, send anything
                             // that had got queued up whilst we were getting
@@ -115,11 +117,13 @@ class EditorTunnel {
                             // WS to local node-red has closed. Send a notification
                             // to the platform so it can close the proxied editor
                             // websocket to match
-                            this.socket?.send(JSON.stringify({
-                                id: request.id,
-                                ws: true,
-                                closed: true
-                            }))
+                            if (this.socket?.readyState === WebSocket.OPEN) {
+                                this.socket.send(JSON.stringify({
+                                    id: request.id,
+                                    ws: true,
+                                    closed: true
+                                }))
+                            }
                             thisTunnel.wsClients[request.id]?.removeAllListeners()
                             thisTunnel.wsClients[request.id] = null
                         })
@@ -190,22 +194,26 @@ class EditorTunnel {
                     got(fullUrl, options).then(response => {
                         // debug(`proxy [${request.method}] ${fullUrl} : sending response: status ${response.statusCode}`)
                         // send response back to the forge
-                        this.socket?.send(JSON.stringify({
-                            id: request.id,
-                            headers: response.headers,
-                            body: response.rawBody,
-                            status: response.statusCode
-                        }))
+                        if (this.socket?.readyState === WebSocket.OPEN) {
+                            this.socket.send(JSON.stringify({
+                                id: request.id,
+                                headers: response.headers,
+                                body: response.rawBody,
+                                status: response.statusCode
+                            }))
+                        }
                     }).catch(_err => {
                         // debug(`proxy [${request.method}] ${fullUrl} : error ${_err.toString()}`)
                         // ↓ useful for debugging but noisy due to .map files
                         // console.log(_err)
                         // console.log(JSON.stringify(request))
-                        this.socket?.send(JSON.stringify({
-                            id: request.id,
-                            body: undefined,
-                            status: 404
-                        }))
+                        if (this.socket?.readyState === WebSocket.OPEN) {
+                            this.socket.send(JSON.stringify({
+                                id: request.id,
+                                body: undefined,
+                                status: 404
+                            }))
+                        }
                     })
                 }
             })


### PR DESCRIPTION
fixes #183 

## Description

1. Ensure `readyState` is `OPEN` before attempting a send
2. Provide a small amount of grace if an unexpected packet arrives (improves reconnection success without spamming logs and unnecessarily disconnecting the WS)

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

