### PR TITLE
Implement quick connect in device agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,12 @@ mkdir c:\opt\flowfuse-device
 ### `device.yml` - for a single device
 
 When the device is registered on the FlowFuse platform, a group of configuration
-details are provided. These can be copied from the platform, or downloaded directly
-as a yml file.
+details are provided. These can be copied from the platform, downloaded directly
+as a yml file or pulled from the FlowFuse server using the Quick Connect command
+that is issued with the configuration details. More details on this can be found
+in the [FlowFuse documentation](https://flowfuse.com/docs/device-agent/introduction/).
 
-This file should be copied into the working directory as `device.yml`.
+This file should exist in the working directory as `device.yml`.
 
 A different config file can be specified with the `-c/--config` option.
 
@@ -219,6 +221,13 @@ Web UI Options
   --ui-user string    Web UI username. Required if --ui is specified
   --ui-pass string    Web UI password. Required if --ui is specified
   --ui-runtime mins   Time the Web UI server is permitted to run. Default: 10
+
+Quick Connect command
+
+  -q, --qc           Quick Connect a device agent. This will pull the device.yml file from the
+                     FlowFuse server, setup your device then exit
+  -o, --otc string   One time code. Required for Quick Connect
+  -u, --ff-url url   URL of FlowFuse. Required for Quick Connect
 
 Global Options
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ mkdir c:\opt\flowfuse-device
 
 When the device is registered on the FlowFuse platform, a group of configuration
 details are provided. These can be copied from the platform, downloaded directly
-as a yml file or pulled from the FlowFuse server using the Quick Connect command
-that is issued with the configuration details. More details on this can be found
+as a yml file or pulled from the FlowFuse server using the command issued by the
+platform when you create a device. More details on this can be found
 in the [FlowFuse documentation](https://flowfuse.com/docs/device-agent/introduction/).
 
 This file should exist in the working directory as `device.yml`.
@@ -222,12 +222,10 @@ Web UI Options
   --ui-pass string    Web UI password. Required if --ui is specified
   --ui-runtime mins   Time the Web UI server is permitted to run. Default: 10
 
-Quick Connect command
+Setup command
 
-  -q, --qc           Quick Connect a device agent. This will pull the device.yml file from the
-                     FlowFuse server, setup your device then exit
-  -o, --otc string   One time code. Required for Quick Connect
-  -u, --ff-url url   URL of FlowFuse. Required for Quick Connect
+  -o, --otc string   Setup device using a one time code
+  -u, --ff-url url   URL of FlowFuse. Required for setup
 
 Global Options
 

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ Please ensure the parent directory is writable, or set a different path with -d`
             // e.g. ab-cd-ef
             quit('Quick Connect requires parameter --otc to be 8 or more characters', 2)
         }
-        AgentManager.quickConnectDevice(options.ffUrl, options.otc, options.dir).then((success) => {
+        AgentManager.quickConnectDevice().then((success) => {
             if (success) {
                 const runCommandInfo = ['flowfuse-device-agent']
                 if (options.dir !== '/opt/flowfuse-device') {

--- a/index.js
+++ b/index.js
@@ -101,6 +101,36 @@ Please ensure the parent directory is writable, or set a different path with -d`
     delete options.config
     AgentManager.init(options)
 
+    if (options.qc) {
+        // Quick Connect mode
+        if (!options.ffUrl) {
+            quit('Quick Connect requires --ff-url to be set', 2)
+        }
+        if (!options.otc || options.otc.length < 8) {
+            // 8 is the minimum length of an OTC
+            // e.g. ab-cd-ef
+            quit('Quick Connect requires parameter --otc to be 8 or more characters', 2)
+        }
+        AgentManager.quickConnectDevice(options.ffUrl, options.otc, options.dir).then((success) => {
+            if (success) {
+                const runCommandInfo = ['flowfuse-device-agent']
+                if (options.dir !== '/opt/flowfuse-device') {
+                    runCommandInfo.push(`-d ${options.dir}`)
+                }
+                info('Quick Connect was successful, your device is now configured.')
+                info('Device Agent will now exit')
+                info('To run the Device Agent using the configuration created by Quick Connect, run:')
+                info(runCommandInfo.join(' '))
+                quit()
+            } else {
+                throw new Error('Quick Connect was unsuccessful')
+            }
+        }).catch((err) => {
+            quit(err.message, 2)
+        })
+        return
+    }
+
     info('FlowFuse Device Agent')
     info('----------------------')
 

--- a/lib/AgentManager.js
+++ b/lib/AgentManager.js
@@ -258,7 +258,7 @@ class AgentManager {
             const anEndpoint = new URL('/api/v1/settings/', provisioningConfig.forgeURL)
             const { host, ip, forgeOk } = await this._getDeviceInfo(anEndpoint)
             if (!forgeOk) {
-                throw new Error('Unable to connect to the Forge Platform')
+                throw new Error('Unable to connect to the FlowFuse Platform')
             }
 
             // Instruct platform to re-generate credentials for this device, passing in the agentHost field and the quickConnect flag

--- a/lib/AgentManager.js
+++ b/lib/AgentManager.js
@@ -234,14 +234,14 @@ class AgentManager {
         }
     }
 
-    async quickConnectDevice (ffURL, otc) {
+    async quickConnectDevice () {
         debug('Quick connecting device')
 
         // sanity check the parameters
         const provisioningConfig = {
             quickConnectMode: true,
-            forgeURL: ffURL,
-            token: Buffer.from(otc).toString('base64')
+            forgeURL: this.options.ffUrl,
+            token: Buffer.from(this.options.otc).toString('base64')
         }
         let success = false
         let postResponse = null

--- a/lib/AgentManager.js
+++ b/lib/AgentManager.js
@@ -179,7 +179,7 @@ class AgentManager {
             }
 
             // Get the local IP address / MAC / Hostname of the device for use in naming
-            const { host, ip, mac, forgeOk } = await this._getDeviceInfo(provisioningConfig.forgeURL)
+            const { host, ip, mac, forgeOk } = await this._getDeviceInfo(provisioningConfig.forgeURL, this.configuration?.token)
             if (!forgeOk) {
                 throw new Error('Unable to connect to the Forge Platform')
             }
@@ -234,6 +234,72 @@ class AgentManager {
         }
     }
 
+    async quickConnectDevice (ffURL, otc) {
+        debug('Quick connecting device')
+
+        // sanity check the parameters
+        const provisioningConfig = {
+            quickConnectMode: true,
+            forgeURL: ffURL,
+            token: Buffer.from(otc).toString('base64')
+        }
+        let success = false
+        let postResponse = null
+
+        const url = new URL('/api/v1/devices/', provisioningConfig.forgeURL)
+        try {
+            // before we do anything, check if the device can be provisioned
+            // These checks will ensure files are writable and the necessary settings are present
+            if (await this.canBeProvisioned(provisioningConfig) !== true) {
+                throw new Error('Device cannot be provisioned. Check the logs for more information.')
+            }
+
+            // Get the local IP address / MAC / Hostname of the device to generate a value for the agentHost field
+            const anEndpoint = new URL('/api/v1/settings/', provisioningConfig.forgeURL)
+            const { host, ip, forgeOk } = await this._getDeviceInfo(anEndpoint)
+            if (!forgeOk) {
+                throw new Error('Unable to connect to the Forge Platform')
+            }
+
+            // Instruct platform to re-generate credentials for this device, passing in the agentHost field and the quickConnect flag
+            // NOTE: the OTC is passed in the Authorization header
+            // NOTE: the OTC token is 100% single use. The platform deletes it upon use regardless of the device-agent successfully writing the config file
+            postResponse = await got.post(url, {
+                headers: {
+                    'user-agent': `FlowFuse Device Agent v${this.configuration?.version || ' unknown'}`,
+                    authorization: `Bearer ${provisioningConfig.token}`
+                },
+                timeout: {
+                    request: 10000
+                },
+                json: { quickConnect: true, agentHost: host || ip }
+            })
+
+            if (postResponse?.statusCode !== 200) {
+                throw new Error(`${postResponse.statusMessage} (${postResponse.statusCode})`)
+            }
+            success = true
+        } catch (err) {
+            warn(`Problem encountered during provisioning: ${err.toString()}`)
+            success = false
+        }
+
+        if (!success) {
+            return false
+        }
+
+        try {
+            // * At this point, the one-time-code is spent (deleted) and we have all the info we need to update the config
+            const provisioningData = JSON.parse(postResponse.body)
+            provisioningData.forgeURL = provisioningData.forgeURL || provisioningConfig.forgeURL
+            await this._provisionDevice(provisioningData)
+            return true
+        } catch (err) {
+            warn(`Error provisioning device: ${err.toString()}`)
+            throw err
+        }
+    }
+
     async canBeProvisioned (provisioningConfig) {
         try {
             if (!this.options) {
@@ -245,12 +311,24 @@ class AgentManager {
                 warn('Device file not specified. Device cannot be provisioned')
                 return false
             }
-            if (!provisioningConfig || !provisioningConfig.provisioningMode || !provisioningConfig.provisioningTeam || !provisioningConfig.token) {
-                warn(`Credentials file '${deviceFile}' is not a valid provisioning file. Device cannot be provisioned`)
+            if (!provisioningConfig) {
+                warn('Provisioning config not specified. Device cannot be provisioned')
                 return false
             }
+            // Using One-Time-code or provisioning token?
+            if (provisioningConfig.quickConnectMode) { // OTC mode
+                if (!this.options.otc) {
+                    warn('One time code not specified. Device cannot be provisioned')
+                    return false
+                }
+            } else { // provisioning token mode
+                if (!provisioningConfig.provisioningMode || !provisioningConfig.provisioningTeam || !provisioningConfig.token) {
+                    warn(`Credentials file '${deviceFile}' is not a valid provisioning file. Device cannot be provisioned`)
+                    return false
+                }
+            }
             if (!provisioningConfig.forgeURL) {
-                warn('Forge URL not specified. Device cannot be provisioned')
+                warn('FlowFuse URL not specified. Device cannot be provisioned')
                 return false
             }
             const deviceFileStat = pathStat(deviceFile)
@@ -269,43 +347,54 @@ class AgentManager {
     }
 
     // #region Private Methods
-    async _getDeviceInfo (forgeURL) {
-        const ifs = os.networkInterfaces()
+    async _getDeviceInfo (forgeURL, token) {
         const ip2mac = {}
         const result = { host: os.hostname(), ip: null, mac: null, forgeOk: false }
-
-        let firstMacNotInternal = null
-        // eslint-disable-next-line no-unused-vars
-        for (const [name, ifaces] of Object.entries(ifs)) {
-            for (const iface of ifaces) {
-                if (iface.family === 'IPv4' || iface.family === 'IPv6') {
-                    ip2mac[iface.address] = iface.mac
-                    if (!firstMacNotInternal && !iface.internal) {
-                        firstMacNotInternal = iface.mac
+        try {
+            const ifs = os.networkInterfaces()
+            let firstMacNotInternal = null
+            // eslint-disable-next-line no-unused-vars
+            for (const [name, ifaces] of Object.entries(ifs)) {
+                for (const iface of ifaces) {
+                    if (iface.family === 'IPv4' || iface.family === 'IPv6') {
+                        ip2mac[iface.address] = iface.mac
+                        if (!firstMacNotInternal && !iface.internal) {
+                            firstMacNotInternal = iface.mac
+                        }
                     }
                 }
             }
-        }
 
-        if (forgeURL) {
-            let forgeCheck
-            try {
-                forgeCheck = await got.get(forgeURL, {
-                    headers: {
-                        'user-agent': `FlowFuse Device Agent v${this.configuration.version}`,
-                        authorization: `Bearer ${this.configuration.token}`
-                    },
-                    timeout: {
-                        request: 5000
-                    }
-                })
-                result.ip = forgeCheck?.socket?.localAddress
-                result.mac = ip2mac[result.ip] || result.ip
-                result.mac = result.mac || firstMacNotInternal
-            } catch (_error) {
-                // ignore
+            if (forgeURL) {
+                let forgeCheck
+                const headers = {
+                    'user-agent': `FlowFuse Device Agent v${this.options?.version || ' unknown'}`
+                }
+                if (token) {
+                    headers.authorization = `Bearer ${token}`
+                }
+                try {
+                    forgeCheck = await got.get(forgeURL, {
+                        headers,
+                        timeout: {
+                            request: 5000
+                        }
+                    })
+                    result.ip = forgeCheck?.socket?.localAddress
+                    result.mac = ip2mac[result.ip] || result.ip
+                    result.mac = result.mac || firstMacNotInternal
+                } catch (_error) {
+                    result._error = _error
+                    // ignore
+                }
+                if (token) {
+                    result.forgeOk = forgeCheck?.statusCode === 200
+                } else {
+                    result.forgeOk = (forgeCheck?.statusCode >= 200 || forgeCheck?.statusCode <= 404) // no token, so any response is pretty much OK
+                }
             }
-            result.forgeOk = forgeCheck?.statusCode === 200
+        } catch (err) {
+            // non fatal error, ignore and return what we have
         }
         return result
     }

--- a/lib/AgentManager.js
+++ b/lib/AgentManager.js
@@ -418,9 +418,9 @@ class AgentManager {
             autoProvisioned: true
         }
         if (this.options?.otc) {
-            deviceJS.quickConnected = true
-            // when _provisionDevice is called, we are either quick connecting or auto-provisioning
+            // when _provisionDevice is called, it was either cli-setup or auto-provisioned
             // not both! delete the other flag
+            deviceJS.cliSetup = true
             delete deviceJS.autoProvisioned
         }
         const deviceYAML = yaml.stringify(deviceJS)

--- a/lib/AgentManager.js
+++ b/lib/AgentManager.js
@@ -235,7 +235,7 @@ class AgentManager {
     }
 
     async quickConnectDevice () {
-        debug('Quick connecting device')
+        debug('Setting up device')
 
         // sanity check the parameters
         const provisioningConfig = {
@@ -318,7 +318,11 @@ class AgentManager {
             // Using One-Time-code or provisioning token?
             if (provisioningConfig.quickConnectMode) { // OTC mode
                 if (!this.options.otc) {
-                    warn('One time code not specified. Device cannot be provisioned')
+                    warn('One time code not specified. Device cannot be setup')
+                    return false
+                }
+                if (!this.options.ffUrl) {
+                    warn('FlowFuse URL not specified. Device cannot be setup')
                     return false
                 }
             } else { // provisioning token mode
@@ -385,12 +389,12 @@ class AgentManager {
                     result.mac = result.mac || firstMacNotInternal
                 } catch (_error) {
                     result._error = _error
-                    // ignore
+                    forgeCheck = _error.response
                 }
                 if (token) {
-                    result.forgeOk = forgeCheck?.statusCode === 200
+                    result.forgeOk = [200, 204].includes(forgeCheck?.statusCode)
                 } else {
-                    result.forgeOk = (forgeCheck?.statusCode >= 200 || forgeCheck?.statusCode <= 404) // no token, so any response is pretty much OK
+                    result.forgeOk = [200, 204, 401, 403, 404].includes(forgeCheck?.statusCode) // got _a_ response from the server, good enough for an existence check
                 }
             }
         } catch (err) {
@@ -413,7 +417,7 @@ class AgentManager {
             brokerPassword: credentials.broker?.password,
             autoProvisioned: true
         }
-        if (this.options?.qc === true) {
+        if (this.options?.otc) {
             deviceJS.quickConnected = true
             // when _provisionDevice is called, we are either quick connecting or auto-provisioning
             // not both! delete the other flag

--- a/lib/AgentManager.js
+++ b/lib/AgentManager.js
@@ -413,6 +413,12 @@ class AgentManager {
             brokerPassword: credentials.broker?.password,
             autoProvisioned: true
         }
+        if (this.options?.qc === true) {
+            deviceJS.quickConnected = true
+            // when _provisionDevice is called, we are either quick connecting or auto-provisioning
+            // not both! delete the other flag
+            delete deviceJS.autoProvisioned
+        }
         const deviceYAML = yaml.stringify(deviceJS)
         const deviceFile = this.options.deviceFile
         const backupFile = `${deviceFile}.bak`

--- a/lib/AgentManager.js
+++ b/lib/AgentManager.js
@@ -272,7 +272,7 @@ class AgentManager {
                 timeout: {
                     request: 10000
                 },
-                json: { quickConnect: true, agentHost: host || ip }
+                json: { setup: true, agentHost: host || ip }
             })
 
             if (postResponse?.statusCode !== 200) {

--- a/lib/cli/args.js
+++ b/lib/cli/args.js
@@ -105,5 +105,28 @@ module.exports = [
         typeLabel: '{underline mins}',
         defaultValue: 10,
         group: 'ui'
+    },
+    {
+        name: 'qc',
+        description: 'Quick Connect a device agent. This will pull the device.yml file from the FlowFuse server, setup your device then exit',
+        type: Boolean,
+        alias: 'q',
+        group: 'setup'
+    },
+    {
+        name: 'otc',
+        description: 'One time code. Required for Quick Connect',
+        type: String,
+        alias: 'o',
+        typeLabel: '{underline string}',
+        group: 'setup'
+    },
+    {
+        name: 'ff-url',
+        description: 'URL of FlowFuse. Required for Quick Connect',
+        type: String,
+        alias: 'u',
+        typeLabel: '{underline url}',
+        group: 'setup'
     }
 ]

--- a/lib/cli/args.js
+++ b/lib/cli/args.js
@@ -107,15 +107,8 @@ module.exports = [
         group: 'ui'
     },
     {
-        name: 'qc',
-        description: 'Quick Connect a device agent. This will pull the device.yml file from the FlowFuse server, setup your device then exit',
-        type: Boolean,
-        alias: 'q',
-        group: 'setup'
-    },
-    {
         name: 'otc',
-        description: 'One time code. Required for Quick Connect',
+        description: 'Setup device using a one time code',
         type: String,
         alias: 'o',
         typeLabel: '{underline string}',
@@ -123,7 +116,7 @@ module.exports = [
     },
     {
         name: 'ff-url',
-        description: 'URL of FlowFuse. Required for Quick Connect',
+        description: 'URL of FlowFuse. Required for setup',
         type: String,
         alias: 'u',
         typeLabel: '{underline url}',

--- a/lib/cli/usage.js
+++ b/lib/cli/usage.js
@@ -20,7 +20,7 @@ module.exports = {
                 group: ['ui']
             },
             {
-                header: 'Device Quick Connect Setup',
+                header: 'Quick Connect command',
                 optionList: require('./args'),
                 group: ['setup']
             },

--- a/lib/cli/usage.js
+++ b/lib/cli/usage.js
@@ -20,7 +20,7 @@ module.exports = {
                 group: ['ui']
             },
             {
-                header: 'Quick Connect command',
+                header: 'Setup command',
                 optionList: require('./args'),
                 group: ['setup']
             },

--- a/lib/cli/usage.js
+++ b/lib/cli/usage.js
@@ -20,6 +20,11 @@ module.exports = {
                 group: ['ui']
             },
             {
+                header: 'Device Quick Connect Setup',
+                optionList: require('./args'),
+                group: ['setup']
+            },
+            {
                 header: 'Global Options',
                 optionList: require('./args'),
                 group: ['global']

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,6 +1,7 @@
 let verbose = false
 function log (msg, level) {
-    console.log(`[AGENT] ${new Date().toLocaleString([], { dateStyle: 'medium', timeStyle: 'medium' })} ${level || 'info'}:`, msg)
+    const date = new Date()
+    console.log(`[AGENT] ${date.toLocaleDateString()} ${date.toLocaleTimeString()} [${level || 'info'}] ${msg}`)
 }
 module.exports = {
     initLogger: configuration => { verbose = configuration.verbose },

--- a/test/unit/lib/AgentManager_spec.js
+++ b/test/unit/lib/AgentManager_spec.js
@@ -80,6 +80,91 @@ describe('Test the AgentManager', function () {
         AgentManager.configuration.should.have.property('forgeURL', 'http://localhost:9999')
         should(AgentManager.configuration.provisioningMode !== true).be.true()
     })
+    it('Agent Manager should request config from FlowFuse when started in Quick Connect mode', async function () {
+        const deviceFile = path.join(configDir, 'project', 'device.yml')
+        // setup a web server to mock the FlowFuse server
+        let httpserver
+        try {
+            httpserver = require('http').createServer((req, res) => {
+                // 2 routes: api/vi/settings (for check in) and api/v1/devices (for using the OTC)
+                if (req.url === '/api/v1/settings/') {
+                    console.log('/api/v1/settings')
+                    res.writeHead(200, { 'Content-Type': 'application/json' })
+                    res.end(JSON.stringify({}))
+                } else if (req.url === '/api/v1/devices/') {
+                    console.log('/api/v1/devices/')
+                    res.writeHead(200, { 'Content-Type': 'application/json' })
+                    res.end(JSON.stringify({
+                        version: '2.1',
+                        id: 'device-hash-id',
+                        forgeURL: 'http://localhost:3000',
+                        credentials: {
+                            token: 'abcd',
+                            credentialSecret: 'yoohoo',
+                            forgeURL: 'http://localhost:3000',
+                            broker: {
+                                url: 'mqtt://localhost:8883',
+                                username: 'broker:user',
+                                password: 'broker:pass'
+                            }
+                        }
+                    }))
+                } else {
+                    console.log('404')
+                    res.writeHead(404)
+                    res.end()
+                }
+            })
+            httpserver.listen(9753)
+
+            // init the AgentManager in Quick Connect mode
+            const options = {
+                qc: true,
+                ffUrl: 'http://localhost:9753',
+                otc: 'one-time-code',
+                dir: configDir,
+                deviceFile
+            }
+            AgentManager.init(options)
+            sinon.spy(AgentManager, '_provisionDevice')
+
+            // perform the Quick Connect
+            await AgentManager.quickConnectDevice()
+
+            // check _provisionDevice was called
+            AgentManager._provisionDevice.calledOnce.should.be.true()
+            AgentManager._provisionDevice.args[0][0].should.be.an.Object() // called with the `device` object
+            const provisioningData = AgentManager._provisionDevice.args[0][0]
+            provisioningData.should.have.property('version').and.be.a.String()
+            provisioningData.should.have.property('id', 'device-hash-id')
+            provisioningData.should.have.property('credentials').and.be.an.Object()
+            provisioningData.credentials.should.have.property('token', 'abcd')
+            provisioningData.credentials.should.have.property('credentialSecret', 'yoohoo')
+            provisioningData.credentials.should.have.property('forgeURL', 'http://localhost:3000')
+            provisioningData.credentials.should.have.property('broker').and.be.an.Object()
+            provisioningData.credentials.broker.should.have.property('url', 'mqtt://localhost:8883')
+            provisioningData.credentials.broker.should.have.property('username', 'broker:user')
+            provisioningData.credentials.broker.should.have.property('password', 'broker:pass')
+
+            // check the config file was created and contains the correct data
+            const deviceConfig = await fs.readFile(deviceFile, 'utf8')
+            deviceConfig.should.match(/deviceId: device-hash-id/)
+            deviceConfig.should.match(/forgeURL: http:\/\/localhost:3000/)
+            deviceConfig.should.match(/credentialSecret: yoohoo/)
+            deviceConfig.should.match(/token: abcd/)
+            deviceConfig.should.match(/brokerURL: mqtt:\/\/localhost:8883/)
+            deviceConfig.should.match(/brokerUsername: broker:user/)
+            deviceConfig.should.match(/brokerPassword: broker:pass/)
+            deviceConfig.should.match(/quickConnected: true/)
+        } catch (error) {
+            console.log(error)
+            throw error
+        } finally {
+            // cleanup
+            httpserver.close()
+            AgentManager._provisionDevice.restore()
+        }
+    })
     it('Agent Manager should call agent start (regular credentials)', async function () {
         this.skip() // TODO: fix this test
         const deviceFile = path.join(configDir, 'project', 'device.yml')

--- a/test/unit/lib/AgentManager_spec.js
+++ b/test/unit/lib/AgentManager_spec.js
@@ -147,7 +147,7 @@ describe('Test the AgentManager', function () {
             deviceConfig.should.match(/brokerURL: mqtt:\/\/localhost:8883/)
             deviceConfig.should.match(/brokerUsername: broker:user/)
             deviceConfig.should.match(/brokerPassword: broker:pass/)
-            deviceConfig.should.match(/quickConnected: true/)
+            deviceConfig.should.match(/cliSetup: true/)
         } catch (error) {
             console.log(error)
             throw error

--- a/test/unit/lib/AgentManager_spec.js
+++ b/test/unit/lib/AgentManager_spec.js
@@ -86,13 +86,7 @@ describe('Test the AgentManager', function () {
         let httpserver
         try {
             httpserver = require('http').createServer((req, res) => {
-                // 2 routes: api/vi/settings (for check in) and api/v1/devices (for using the OTC)
-                if (req.url === '/api/v1/settings/') {
-                    console.log('/api/v1/settings')
-                    res.writeHead(200, { 'Content-Type': 'application/json' })
-                    res.end(JSON.stringify({}))
-                } else if (req.url === '/api/v1/devices/') {
-                    console.log('/api/v1/devices/')
+                if (req.url === '/api/v1/devices/') {
                     res.writeHead(200, { 'Content-Type': 'application/json' })
                     res.end(JSON.stringify({
                         version: '2.1',
@@ -110,16 +104,14 @@ describe('Test the AgentManager', function () {
                         }
                     }))
                 } else {
-                    console.log('404')
                     res.writeHead(404)
-                    res.end()
+                    res.end('{}')
                 }
             })
             httpserver.listen(9753)
 
             // init the AgentManager in Quick Connect mode
             const options = {
-                qc: true,
                 ffUrl: 'http://localhost:9753',
                 otc: 'one-time-code',
                 dir: configDir,


### PR DESCRIPTION
## Description


* Support new args for initialising setup from CLI using a one time code
  * `-o/--otc` - One Time Code
  * `-u/--ff-url` - URL of FlowFuse platform to connect and spend the OTC
* Updates to README.md to document new args
* Adds test "Agent Manager should request config from FlowFuse when started in Quick Connect mode"

### Examples
`flowfuse-device-agent -o free-pond-grouse -u https:app.my-ff.org`
```bash
[AGENT] 29/01/2024 15:51:56 [info] Entering Device setup...
[AGENT] 29/01/2024 15:51:56 [info] Device setup was successful
[AGENT] 29/01/2024 15:51:56 [info] To start the Device Agent with the new configuration run the following command:
[AGENT] 29/01/2024 15:51:56 [info] flowfuse-device-agent
```

2nd run: `flowfuse-device-agent -o free-pond-grouse -u https:app.my-ff.org`
```bash
[AGENT] 30/01/2024 09:00:50 [info] Entering Device setup...
[AGENT] 30/01/2024 09:00:50 [warn] Problem encountered during provisioning: HTTPError: Response code 401 (Unauthorized)
[AGENT] 30/01/2024 09:00:50 [warn] Device setup was unsuccessful
```


`flowfuse-device-agent -o red-horse-velvet -u https:app.my-ff.org -d c:/opt/dev1`
```bash
[AGENT] 29/01/2024 15:51:56 [info] Entering Device setup...
[AGENT] 29/01/2024 15:51:56 [info] Device setup was successful
[AGENT] 29/01/2024 15:51:56 [info] To start the Device Agent with the new configuration run the following command:
[AGENT] 29/01/2024 15:51:56 [info] flowfuse-device-agent -d c:/opt/dev1
```

`flowfuse-device-agent -u https:app.my-ff.org -d c:/opt/dev1`
```bash
[AGENT] 30/01/2024 09:01:53 [warn] Device setup requires parameter --otc to be 8 or more characters
```


`flowfuse-device-agent -o free-pond-grouse `
```bash
[AGENT] 30/01/2024 09:02:54 [warn] Device setup requires parameter --ff-url to be set
```



<details>
<summary> Prior to  redesign 29-001-2024 </summary>

* Support new args for Quick Connect
  * `-q/--qc` - boolean flag to init Quick Connect
  * `-o/--otc` - One Time Code
  * `-u/--ff-url` - URL of FlowFuse platform to connect and spend the OTC
* Updates to README.md to document new args
* Adds test "Agent Manager should request config from FlowFuse when started in Quick Connect mode"
</details>

## Related Issue(s)

[#3256](https://github.com/FlowFuse/flowfuse/issues/3256)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

