### PR TITLE
Wire up Node-RED instance audit events to FF

### DIFF
--- a/lib/auditLogger/index.js
+++ b/lib/auditLogger/index.js
@@ -1,0 +1,37 @@
+/*
+ * The below code should be kept in-sync with nr-launcher/lib/auditLogger/index.js
+ */
+
+const { default: got } = require('got')
+
+module.exports = (settings) => {
+    const loggingURL = settings.loggingURL
+    const token = settings.token
+    const logger = function (msg) {
+        if (/^(comms\.|.*\.get$)/.test(msg.event)) {
+            // Ignore comms events and any .get event that is just reading data
+            return
+        }
+        if (/^auth/.test(msg.event) && !/^auth.log/.test(msg.event)) {
+            return
+        }
+        if (msg.user) {
+            msg.user = msg.user.userId
+        }
+        delete msg.username
+        delete msg.level
+        got.post(loggingURL, {
+            json: msg,
+            responseType: 'json',
+            headers: {
+                'user-agent': 'FlowFuse Device Agent Audit Logging v0.1',
+                authorization: 'Bearer ' + token
+            }
+        }).catch(err => {
+            // ignore errors for now
+            console.log(err)
+        })
+    }
+
+    return logger
+}

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -28,7 +28,7 @@ class Launcher {
         this.restartCount = 0
         this.startTime = []
         this.state = 'stopped'
-
+        this.auditLogURL = `${this.config.forgeURL}/logging/device/${this.config.deviceId}/audit`
         this.projectDir = path.join(this.config.dir, 'project')
 
         this.files = {
@@ -176,6 +176,12 @@ class Launcher {
                 projectID: this.project || undefined,
                 applicationID: this.application || undefined,
                 teamID,
+                deviceId: this.config.deviceId,
+                auditLogger: {
+                    url: this.auditLogURL,
+                    token: this.config.token,
+                    bin: path.join(__dirname, 'auditLogger', 'index.js')
+                },
                 projectLink
             }
         }

--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -125,10 +125,7 @@ if (settings.flowforge.auditLogger?.bin && settings.flowforge.auditLogger?.url) 
             level: 'off',
             audit: true,
             handler: require(settings.flowforge.auditLogger.bin),
-            baseURL: settings.flowforge.baseURL,
             loggingURL: settings.flowforge.auditLogger.url,
-            projectID: settings.flowforge.projectID,
-            deviceID: settings.flowforge.deviceID,
             token: settings.flowforge.auditLogger.token
         }
     } catch (e) {

--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -119,6 +119,23 @@ const runtimeSettings = {
     editorTheme: { ...editorTheme }
 }
 
+if (settings.flowforge.auditLogger?.bin && settings.flowforge.auditLogger?.url) {
+    try {
+        runtimeSettings.logging.auditLogger = {
+            level: 'off',
+            audit: true,
+            handler: require(settings.flowforge.auditLogger.bin),
+            baseURL: settings.flowforge.baseURL,
+            loggingURL: settings.flowforge.auditLogger.url,
+            projectID: settings.flowforge.projectID,
+            deviceID: settings.flowforge.deviceID,
+            token: settings.flowforge.auditLogger.token
+        }
+    } catch (e) {
+        console.warn('Could not initialise device audit logging. Audit events will not be logged to the platform')
+    }
+}
+
 if (settings.https) {
     ;['key', 'ca', 'cert'].forEach(key => {
         const filePath = settings.https[`${key}Path`]

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
     "version": "2.0.0",
     "description": "An Edge Agent for running Node-RED instances deployed from the FlowFuse Platform",
     "exports": {
-        "./libraryPlugin": "./lib/plugins/libraryPlugin.js"
+        "./libraryPlugin": "./lib/plugins/libraryPlugin.js",
+        "./auditLogger": "./lib/auditLogger/index.js"
     },
     "main": "index.js",
     "repository": {

--- a/test/unit/lib/launcher_spec.js
+++ b/test/unit/lib/launcher_spec.js
@@ -174,6 +174,7 @@ describe('Launcher', function () {
         const setFile = await fs.readFile(path.join(config.dir, 'project', 'settings.json'))
         const settings = JSON.parse(setFile)
         settings.should.have.property('flowforge')
+        settings.flowforge.should.have.property('deviceId', configWithPlatformInfo.deviceId)
         settings.flowforge.should.have.property('auditLogger').and.be.an.Object()
         settings.flowforge.auditLogger.should.have.property('url', expectedURL)
         settings.flowforge.auditLogger.should.have.property('token', configWithPlatformInfo.token)

--- a/test/unit/lib/launcher_spec.js
+++ b/test/unit/lib/launcher_spec.js
@@ -180,4 +180,21 @@ describe('Launcher', function () {
         settings.flowforge.auditLogger.should.have.property('token', configWithPlatformInfo.token)
         settings.flowforge.auditLogger.should.have.property('bin', path.join(__dirname, '..', '..', '..', 'lib', 'auditLogger', 'index.js'))
     })
+    it('settings.js loads audit logger with settings from config', async function () {
+        const launcher = newLauncher(configWithPlatformInfo, null, 'projectId', setup.snapshot)
+        const expectedURL = `${configWithPlatformInfo.forgeURL}/logging/device/${configWithPlatformInfo.deviceId}/audit`
+        await launcher.writeSettings()
+
+        // copy the template-settings as settings.js to the test dir
+        await fs.copyFile(path.join(__dirname, '..', '..', '..', 'lib', 'template', 'template-settings.js'), path.join(config.dir, 'project', 'settings.js'))
+        const runtimeSettings = require(path.join(config.dir, 'project', 'settings.js'))
+        should(runtimeSettings).be.an.Object()
+        runtimeSettings.should.have.property('logging').and.be.an.Object()
+        runtimeSettings.logging.should.have.property('auditLogger').and.be.an.Object()
+        runtimeSettings.logging.auditLogger.should.have.property('level', 'off')
+        runtimeSettings.logging.auditLogger.should.have.property('audit', true)
+        runtimeSettings.logging.auditLogger.should.have.property('handler').and.be.a.Function()
+        runtimeSettings.logging.auditLogger.should.have.property('loggingURL', expectedURL)
+        runtimeSettings.logging.auditLogger.should.have.property('token', configWithPlatformInfo.token)
+    })
 })


### PR DESCRIPTION
## Description

* Adds new module `lib/auditLogger/index.js` for inclusing in `settings.js`
* Updates `lib/launcher.js` to update `settings.json` with required properties for the auditLogger module
* Updates `lib/template/template-settings.js` to use the new props in `settings.json` to load the auditLogger module
* Adds test  to ensure `settings.json` gets the necessary property values
* Adds test to ensure `settings.js` loads the new module as a handler under `logging.auditLogger.handler` and also has the necessary properties `loggingURL` & `token` as well as the `level` and `audit` values like nr-launcher has.

## Related Issue(s)

https://github.com/FlowFuse/flowfuse/issues/3357

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

