### PR TITLE
Add support for device actions

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -168,48 +168,36 @@ class Agent {
     }
 
     async restartNR () {
-        try {
-            this.retrySetState(false) // clear any retry timers
-            if (this.launcher) {
-                // using non std state 'restart' to indicate a restart.
-                // This is mainly for consistent logging and tracking of restarts
-                // This will not be persisted to the targetState property
-                await this.launcher.stop(false, 'restart')
-                this.launcher = undefined
-            }
-            await this.updateTargetState(States.RUNNING)
-            await this.setState({ targetState: States.RUNNING })
-            return true
-        } catch (err) {
-            warn(`Error restarting Node-RED: ${err.toString()}`)
-            debug(err)
+        this.retrySetState(false) // clear any retry timers
+        if (this.launcher) {
+            // using non std state 'restart' to indicate a restart.
+            // This is mainly for consistent logging and tracking of restarts
+            // This will not be persisted to the targetState property
+            await this.launcher.stop(false, 'restart')
+            this.launcher = undefined
         }
-        return false
+        await this.updateTargetState(States.RUNNING)
+        await this.setState({ targetState: States.RUNNING })
+        return this.targetState === States.RUNNING
     }
 
     async startNR () {
-        try {
-            await this.updateTargetState(States.RUNNING)
-            await this.setState({ targetState: States.RUNNING })
-            return true
-        } catch (err) {
-            warn(`Error starting Node-RED: ${err.toString()}`)
-            debug(err)
-        }
-        return false
+        await this.updateTargetState(States.RUNNING)
+        await this.setState({ targetState: States.RUNNING })
+        return this.targetState === States.RUNNING
     }
 
     async suspendNR () {
         this.retrySetState(false) // clear any retry timers
         // update the settings to indicate the device is suspended so that upon
         // a reboot the device agent will not start the launcher
-        await this.updateTargetState(States.SUSPENDED)
+        const result = await this.updateTargetState(States.SUSPENDED)
         if (this.launcher) {
             await this.launcher.stop(false, States.SUSPENDED)
             this.launcher = undefined
             this.currentState = States.SUSPENDED
         }
-        return true
+        return result && this.targetState === States.SUSPENDED
     }
 
     async updateTargetState (newState) {
@@ -221,7 +209,9 @@ class Agent {
                 this.targetState = newState
                 await this.saveProject()
             }
+            return true
         }
+        return false
     }
 
     async getCurrentPackage () {

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -7,6 +7,7 @@ const mqttClient = require('./mqtt')
 const Launcher = require('./launcher.js')
 const { info, warn, debug } = require('./logging/log')
 const utils = require('./utils.js')
+const { States, isTargetState, isValidState } = require('./states')
 
 const PROJECT_FILE = 'flowforge-project.json'
 
@@ -24,13 +25,14 @@ class Agent {
         this.currentProject = null
         this.currentApplication = null
         this.currentMode = 'autonomous'
+        this.targetState = config.targetState || States.RUNNING
         this.updating = false
         this.queuedUpdate = null
         /** @type {IntervalJitter} a timer for scheduling retries of `setState()` */
         this.retrySetStateTimer = new IntervalJitter()
         // Track the local state of the agent. Start in 'unknown' state so
         // that the first MQTT check-in will trigger a response
-        this.currentState = 'unknown'
+        this.currentState = States.UNKNOWN
         this.editorToken = null
         this.editorAffinity = null
         // ensure licensed property is present (default to null)
@@ -61,6 +63,7 @@ class Agent {
                     this.currentSnapshot = config.snapshot || null
                     this.currentSettings = config.settings || null
                     this.currentMode = config.mode || 'autonomous'
+                    this.targetState = isTargetState(config.targetState) ? config.targetState : States.RUNNING
                     this.config.licensed = config.licensed || null
                     this.editorToken = config.editorToken || null
                     this.editorAffinity = config.editorAffinity || null
@@ -86,6 +89,7 @@ class Agent {
         }
         info(`  * Settings           : ${this.currentSettings?.hash || 'none'}`)
         info(`  * Operation Mode     : ${this.currentMode || 'unknown'}`)
+        info(`  * Target State       : ${this.targetState || States.RUNNING}`)
         info(`  * Licensed           : ${this.config.licensed === null ? 'unknown' : this.config.licensed ? 'yes' : 'no'}`)
         if (typeof this.currentSettings?.env === 'object') {
             info('Environment :-')
@@ -109,6 +113,7 @@ class Agent {
             snapshot: this.currentSnapshot,
             settings: this.currentSettings,
             mode: this.currentMode,
+            targetState: this.targetState,
             licensed: this.config.licensed,
             editorToken: this.editorToken,
             editorAffinity: this.editorAffinity
@@ -117,18 +122,28 @@ class Agent {
 
     async start () {
         if (this.config?.provisioningMode) {
-            this.currentState = 'provisioning'
+            this.currentState = States.PROVISIONING
             await this.httpClient.startPolling()
         } else {
             await this.loadProject()
             if (this.config?.brokerURL) {
+                // ensure http comms are stopped if using MQTT
+                this.httpClient.stopPolling()
+                // ensure any existing MQTT comms are stopped before initiating new ones
+                if (this.mqttClient) {
+                    this.mqttClient.stop()
+                }
                 // We have been provided a broker URL to use
                 this.mqttClient = mqttClient.newMQTTClient(this, this.config)
                 this.mqttClient.start()
                 this.mqttClient.setApplication(this.currentApplication)
                 this.mqttClient.setProject(this.currentProject)
             } else {
-                this.currentState = 'stopped'
+                // ensure MQTT comms are stopped if switching to HTTP
+                if (this.mqttClient && this.config?.brokerURL) {
+                    this.mqttClient.stop()
+                }
+                this.currentState = States.STOPPED
                 // Fallback to HTTP polling
                 await this.httpClient.startPolling()
             }
@@ -137,12 +152,75 @@ class Agent {
     }
 
     async stop () {
+        // Stop the launcher before stopping http/mqtt channels to permit
+        // audit logging and  status updates to the platform
+        if (this.launcher) {
+            // Stop the launcher using non std state 'shutdown' to indicate a shutdown.
+            // This is mainly for consistent logging and preventing the auto restart
+            // logic kicking in when the agent is stopped
+            await this.launcher.stop(false, 'shutdown')
+            this.launcher = undefined
+        }
         await this.httpClient.stopPolling()
         if (this.mqttClient) {
             this.mqttClient.stop()
         }
+    }
+
+    async restartNR () {
+        try {
+            this.retrySetState(false) // clear any retry timers
+            if (this.launcher) {
+                // using non std state 'restart' to indicate a restart.
+                // This is mainly for consistent logging and tracking of restarts
+                // This will not be persisted to the targetState property
+                await this.launcher.stop(false, 'restart')
+                this.launcher = undefined
+            }
+            await this.updateTargetState(States.RUNNING)
+            await this.setState({ targetState: States.RUNNING })
+            return true
+        } catch (err) {
+            warn(`Error restarting Node-RED: ${err.toString()}`)
+            debug(err)
+        }
+        return false
+    }
+
+    async startNR () {
+        try {
+            await this.updateTargetState(States.RUNNING)
+            await this.setState({ targetState: States.RUNNING })
+            return true
+        } catch (err) {
+            warn(`Error starting Node-RED: ${err.toString()}`)
+            debug(err)
+        }
+        return false
+    }
+
+    async suspendNR () {
+        this.retrySetState(false) // clear any retry timers
+        // update the settings to indicate the device is suspended so that upon
+        // a reboot the device agent will not start the launcher
+        await this.updateTargetState(States.SUSPENDED)
         if (this.launcher) {
-            await this.launcher.stop()
+            await this.launcher.stop(false, States.SUSPENDED)
+            this.launcher = undefined
+            this.currentState = States.SUSPENDED
+        }
+        return true
+    }
+
+    async updateTargetState (newState) {
+        if (isTargetState(newState)) {
+            const changed = this.targetState !== newState
+            this.targetState = newState
+            if (changed) {
+                this.retrySetState(false) // clear any retry timers
+                this.targetState = newState
+                await this.saveProject()
+            }
         }
     }
 
@@ -179,6 +257,7 @@ class Agent {
             settings: this.currentSettings?.hash || null,
             state: this.launcher?.state || this.currentState,
             mode: this.currentMode,
+            targetState: this.targetState,
             health: {
                 uptime: Math.floor((Date.now() - this.startTime) / 1000),
                 snapshotRestartCount: this.launcher?.restartCount || 0
@@ -188,6 +267,9 @@ class Agent {
         }
         if (this.currentMode === 'developer' && this.editorToken && this.editorAffinity) {
             state.affinity = this.editorAffinity
+        }
+        if (!this.launcher && this.currentState === States.SUSPENDED) {
+            this.state = States.SUSPENDED
         }
         return state
     }
@@ -217,7 +299,19 @@ class Agent {
 
     async setState (newState) {
         debug(newState)
+
+        // If busy updating, queue the update
         if (this.updating) {
+            const queuedUpdateIsTargetStateChange = this.queuedUpdate && typeof this.queuedUpdate === 'object' && utils.hasProperty(this.queuedUpdate, 'targetState')
+            if (queuedUpdateIsTargetStateChange) {
+                // the queued update is a target state change request, lets not overwrite it
+                // unless the new state is also a target state change request
+                const newStateIsTargetStateChange = typeof newState === 'object' && utils.hasProperty(newState, 'targetState')
+                if (newStateIsTargetStateChange) {
+                    this.queuedUpdate = newState
+                }
+                return
+            }
             this.queuedUpdate = newState
             return
         }
@@ -244,7 +338,20 @@ class Agent {
         /** `forgeSnapshot` will be set to the current snapshot in the forge platform *if required* */
         let forgeSnapshot = null
 
-        // first, check if the new state indicates a change of operation mode from the current mode
+        // check to see if this is run state change request
+        if (typeof newState === 'object' && utils.hasProperty(newState, 'targetState')) {
+            if (isTargetState(newState.targetState)) {
+                const changed = newState.targetState !== this.targetState
+                this.targetState = newState.targetState
+                await this.saveProject()
+                if (changed) {
+                    this.retrySetState(false) // since this is a target state change, cancel any retry timers
+                }
+            }
+            delete newState.targetState
+        }
+
+        // next, check if the new state indicates a change of operation mode from the current mode
         // When changing from developer mode to autonomous mode, we need to check if the flows/modules
         // for Node-RED were changed vs the current snapshot on the forge platform.
         // If they differ, we flag that a reload of the snapshot is required.
@@ -266,7 +373,7 @@ class Agent {
                     let _launcher = this.launcher
                     if (!_launcher) {
                         // create a temporary launcher to read the current snapshot on disk
-                        _launcher = Launcher.newLauncher(this.config, this.currentApplication, this.currentProject, this.currentSnapshot, this.currentSettings, this.currentMode)
+                        _launcher = Launcher.newLauncher(this, this.currentApplication, this.currentProject, this.currentSnapshot, this.currentSettings, this.currentMode)
                     }
 
                     try {
@@ -274,7 +381,7 @@ class Agent {
                         this.retrySetState(false) // success - stop retry timer
                     } catch (err) {
                         if (!this.retrySetStateTimer.isRunning) {
-                            this.currentState = 'error'
+                            this.currentState = States.ERROR
                             warn(`Problem getting snapshot: ${err.toString()}`)
                             debug(err)
                             this.retrySetState(newState)
@@ -368,7 +475,7 @@ class Agent {
             // The agent should not be running (bad credentials/device details)
             // Wipe the local configuration
             if (developerMode === false) {
-                this.stop()
+                await this.stop()
                 this.currentSnapshot = null
                 this.currentApplication = null
                 this.currentProject = null
@@ -377,7 +484,7 @@ class Agent {
                 this.editorToken = null
                 this.editorAffinity = null
                 await this.saveProject()
-                this.currentState = 'stopped'
+                this.currentState = States.STOPPED
                 this.updating = false
             }
         } else if (!skipToUpdate && developerMode === false && newState.application === null && this.currentOwnerType === 'application') {
@@ -406,7 +513,7 @@ class Agent {
                 }
             }
             await this.saveProject()
-            this.currentState = 'stopped'
+            this.currentState = States.STOPPED
             this.updating = false
         } else if (!skipToUpdate && developerMode === false && newState.project === null && this.currentOwnerType === 'project') {
             if (this.currentProject) {
@@ -434,7 +541,7 @@ class Agent {
                 }
             }
             await this.saveProject()
-            this.currentState = 'stopped'
+            this.currentState = States.STOPPED
             this.updating = false
         } else if (!skipToUpdate && developerMode === false && newState.snapshot === null) {
             // Snapshot removed, but project/application still set
@@ -478,13 +585,13 @@ class Agent {
                 await this.launcher.stop(true)
                 this.launcher = undefined
             }
-            this.currentState = 'stopped'
+            this.currentState = States.STOPPED
             this.updating = false
         } else {
             // Check if any updates are needed
             let updateSnapshot = false
             let updateSettings = false
-            const unknownOrStopped = (this.currentState === 'unknown' || this.currentState === 'stopped')
+            const unknownOrStopped = (this.currentState === States.UNKNOWN || this.currentState === States.STOPPED)
             const snapShotUpdatePending = !!(!this.currentSnapshot && newState.snapshot)
             const projectUpdatePending = !!(newState.ownerType === 'project' && !this.currentProject && newState.project)
             const applicationUpdatePending = !!(newState.ownerType === 'application' && !this.currentApplication && newState.application)
@@ -539,8 +646,14 @@ class Agent {
                 // Nothing to update.
                 // Start the launcher with the current config, Snapshot & settings
                 if (!this.launcher && this.currentSnapshot) {
-                    this.launcher = Launcher.newLauncher(this.config, this.currentApplication, this.currentProject, this.currentSnapshot, this.currentSettings, this.currentMode)
-                    await this.launcher.start()
+                    let optimisticState = States.STOPPED
+                    if (this.targetState === States.SUSPENDED) {
+                        optimisticState = States.SUSPENDED
+                    } else if (this.targetState === States.RUNNING) {
+                        this.launcher = Launcher.newLauncher(this, this.currentApplication, this.currentProject, this.currentSnapshot, this.currentSettings, this.currentMode)
+                        optimisticState = States.STARTING
+                        await this.launcher.start()
+                    }
                     if (this.mqttClient) {
                         this.mqttClient.setProject(this.currentProject)
                         this.mqttClient.setApplication(this.currentApplication)
@@ -548,8 +661,8 @@ class Agent {
                             this.mqttClient.startTunnel(this.editorToken, this.editorAffinity)
                         }
                     }
+                    this.currentState = optimisticState
                     this.checkIn(2)
-                    this.currentState = 'stopped'
                 }
                 this.updating = false
             } else {
@@ -557,10 +670,10 @@ class Agent {
                 // then start the launcher with the new snapshot and/or settings
 
                 // Stop the launcher if currently running
-                this.currentState = 'updating'
+                this.currentState = States.UPDATING
                 if (this.launcher) {
                     info('Stopping current snapshot')
-                    await this.launcher.stop()
+                    await this.launcher.stop(false, States.UPDATING)
                     this.launcher = undefined
                 }
 
@@ -570,7 +683,7 @@ class Agent {
                         this.retrySetState(false) // success - stop retry timer
                     } catch (err) {
                         if (!this.retrySetStateTimer.isRunning) {
-                            this.currentState = 'error'
+                            this.currentState = States.ERROR
                             warn(`Problem getting snapshot: ${err.toString()}`)
                             debug(err)
                             this.retrySetState(newState)
@@ -586,9 +699,15 @@ class Agent {
                     try {
                         await this.saveProject()
                         this.printAgentStatus('Launching with new settings...')
-                        this.launcher = Launcher.newLauncher(this.config, this.currentApplication, this.currentProject, this.currentSnapshot, this.currentSettings, this.currentMode)
-                        await this.launcher.writeConfiguration({ updateSnapshot, updateSettings })
-                        await this.launcher.start()
+                        let optimisticState = States.STOPPED
+                        if (this.targetState === States.SUSPENDED) {
+                            optimisticState = States.SUSPENDED
+                        } else if (this.targetState === States.RUNNING) {
+                            this.launcher = Launcher.newLauncher(this, this.currentApplication, this.currentProject, this.currentSnapshot, this.currentSettings, this.currentMode)
+                            await this.launcher.writeConfiguration({ updateSnapshot, updateSettings })
+                            optimisticState = States.STARTING
+                            await this.launcher?.start()
+                        }
                         if (this.mqttClient) {
                             this.mqttClient.setProject(this.currentProject)
                             this.mqttClient.setApplication(this.currentApplication)
@@ -596,6 +715,7 @@ class Agent {
                                 this.mqttClient.startTunnel(this.editorToken, this.editorAffinity)
                             }
                         }
+                        this.currentState = optimisticState
                         this.checkIn(2)
                     } catch (err) {
                         warn(`Error whilst starting Node-RED: ${err.toString()}`)
@@ -607,7 +727,15 @@ class Agent {
                 }
             }
         }
-        this.currentState = this.launcher ? 'running' : 'stopped'
+        if (!this.launcher) {
+            if (this.targetState === States.SUSPENDED) {
+                this.currentState = States.SUSPENDED
+            } else if (isValidState(this.currentState) === false) {
+                this.currentState = States.STOPPED
+            }
+        } else {
+            this.currentState = this.launcher?.state || States.RUNNING
+        }
         this.updating = false
         if (this.queuedUpdate) {
             const update = this.queuedUpdate

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -168,12 +168,14 @@ class Agent {
     }
 
     async restartNR () {
+        this.currentState = States.RESTARTING
         this.retrySetState(false) // clear any retry timers
         if (this.launcher) {
-            // using non std state 'restart' to indicate a restart.
-            // This is mainly for consistent logging and tracking of restarts
+            // Stop the launcher using the state 'restarting'
             // This will not be persisted to the targetState property
-            await this.launcher.stop(false, 'restart')
+            // It indicates the launcher it should not attempt to auto restart
+            // the NR process but permit the process to exit gracefully
+            await this.launcher.stop(false, States.RESTARTING)
             this.launcher = undefined
         }
         await this.updateTargetState(States.RUNNING)

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -690,16 +690,25 @@ class Agent {
                 if (this.currentSnapshot?.id) {
                     try {
                         await this.saveProject()
-                        this.printAgentStatus('Launching with new settings...')
                         let optimisticState = States.STOPPED
+                        let performStart = true
+                        this.currentState = States.UPDATING
                         if (this.targetState === States.SUSPENDED) {
+                            this.printAgentStatus('Applying new settings...')
+                            performStart = false
                             optimisticState = States.SUSPENDED
                         } else if (this.targetState === States.RUNNING) {
-                            this.launcher = Launcher.newLauncher(this, this.currentApplication, this.currentProject, this.currentSnapshot, this.currentSettings, this.currentMode)
-                            await this.launcher.writeConfiguration({ updateSnapshot, updateSettings })
+                            this.printAgentStatus('Launching with new settings...')
                             optimisticState = States.STARTING
-                            await this.launcher?.start()
                         }
+                        this.launcher = Launcher.newLauncher(this, this.currentApplication, this.currentProject, this.currentSnapshot, this.currentSettings, this.currentMode)
+                        await this.launcher.writeConfiguration({ updateSnapshot, updateSettings })
+                        if (performStart) {
+                            await this.launcher?.start()
+                        } else {
+                            this.launcher = undefined
+                        }
+
                         if (this.mqttClient) {
                             this.mqttClient.setProject(this.currentProject)
                             this.mqttClient.setApplication(this.currentApplication)

--- a/lib/http.js
+++ b/lib/http.js
@@ -64,6 +64,10 @@ class HTTPClient {
         }
     }
 
+    isPolling () {
+        return this.heartbeat.isRunning
+    }
+
     async checkIn () {
         const payload = this.agent.getState()
         if (!payload) {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -406,7 +406,9 @@ class Launcher {
         })
 
         this.proc.on('exit', async (code, signal) => {
-            const expected = ['shutdown', 'restart', States.UPDATING, States.SUSPENDED].includes(this.stopReason)
+            // determine if Node-RED exited for an expected reason
+            // if yes, don't restart it since it was specifically stopped (e.g. not crashed)
+            const expected = ['shutdown', States.RESTARTING, States.UPDATING, States.SUSPENDED].includes(this.stopReason)
             if (expected) {
                 this.state = States.STOPPED // assume stopped
             } else {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -4,6 +4,7 @@ const fs = require('fs/promises')
 const path = require('path')
 const { log, info, debug, warn, NRlog } = require('./logging/log')
 const { copyDir } = require('./utils')
+const { States } = require('./states')
 
 const MIN_RESTART_TIME = 10000 // 10 seconds
 const MAX_RESTART_COUNT = 5
@@ -22,8 +23,8 @@ const packageJSONTemplate = {
 }
 
 class Launcher {
-    constructor (config, application, project, snapshot, settings, mode) {
-        this.config = config
+    constructor (agent, application, project, snapshot, settings, mode) {
+        this.config = agent?.config
         this.application = application
         this.project = project
         this.snapshot = snapshot
@@ -31,7 +32,12 @@ class Launcher {
         this.mode = mode
         this.restartCount = 0
         this.startTime = []
-        this.state = 'stopped'
+        this.state = States.STOPPED
+        this.stopReason = ''
+        this.installProcess = null
+        this.deferredStop = null
+        /** @type {import('./agent.js').Agent */
+        this.agent = agent
 
         this.auditLogURL = `${this.config.forgeURL}/logging/device/${this.config.deviceId}/audit`
 
@@ -89,6 +95,7 @@ class Launcher {
 
     async installDependencies () {
         info('Installing dependencies')
+        this.state = States.UPDATING
         if (this.config.moduleCache) {
             info('Using module_cache')
             const sourceDir = path.join(this.config.dir, 'module_cache/node_modules')
@@ -105,19 +112,22 @@ class Launcher {
 
             return fs.symlink(sourceDir, targetDir, 'dir')
         } else {
-            return new Promise((resolve, reject) => {
+            this.installProcess = new Promise((resolve, reject) => {
                 childProcess.exec('npm install --production', {
                     cwd: this.projectDir
                 }, (error, stdout, stderr) => {
                     if (!error) {
                         resolve()
+                        this.installProcess = null
                     } else {
                         warn('Install failed')
                         warn(stderr)
                         reject(error)
+                        this.installProcess = null
                     }
                 })
             })
+            return this.installProcess
         }
     }
 
@@ -277,6 +287,7 @@ class Launcher {
         info('Updating configuration files')
         await fs.mkdir(this.projectDir, { recursive: true })
         if (!options || options.updateSnapshot) {
+            this.state = States.INSTALLING
             await this.writeNPMRCFile()
             await this.writePackage()
             await this.installDependencies()
@@ -312,7 +323,8 @@ class Launcher {
         if (this.deferredStop) {
             await this.deferredStop
         }
-        this.state = 'starting'
+
+        this.state = States.STARTING
         if (!existsSync(this.projectDir) ||
             !existsSync(this.files.flows) ||
             !existsSync(this.files.credentials) ||
@@ -356,6 +368,8 @@ class Launcher {
         env.TZ = process.env.TZ ? process.env.TZ : this.settings?.settings?.timeZone
 
         info('Starting Node-RED')
+        this.state = States.STARTING // state may have been changed by stop() or deferredStop or Installing
+        this.stopReason = ''
         const appEnv = env
         const processArgs = [
             '-u',
@@ -388,12 +402,20 @@ class Launcher {
             if (this.startTime.length > MAX_RESTART_COUNT) {
                 this.startTime.shift()
             }
-            this.state = 'running'
+            this.state = States.RUNNING
         })
 
         this.proc.on('exit', async (code, signal) => {
-            this.state = 'stopped'
-            if (!this.shuttingDown) {
+            const expected = ['shutdown', 'restart', States.UPDATING, States.SUSPENDED].includes(this.stopReason)
+            if (expected) {
+                this.state = States.STOPPED // assume stopped
+            } else {
+                this.state = States.CRASHED // assume crashed
+            }
+            if (this.exitCallback) {
+                this.exitCallback()
+            }
+            if (!expected) {
                 let restart = true
                 if (this.startTime.length === MAX_RESTART_COUNT) {
                     let avg = 0
@@ -404,19 +426,14 @@ class Launcher {
                     if (avg < MIN_RESTART_TIME) {
                         // restarting too fast
                         info('Node-RED restart loop detected - stopping')
-                        this.state = 'crashed'
+                        this.state = States.CRASHED
                         restart = false
+                        await this.agent?.checkIn()
                     }
                 }
                 if (restart) {
                     info('Node-RED stopped unexpectedly - restarting')
                     this.start()
-                }
-            } else {
-                // is really shutting down (i.e. was commanded by the
-                // agent, so we won't be doing an auto restart)
-                if (this.exitCallback) {
-                    this.exitCallback()
                 }
             }
         })
@@ -439,8 +456,22 @@ class Launcher {
         this.proc.stderr.on('data', handleLog)
     }
 
-    async stop (clean) {
-        info('Stopping Node-RED')
+    async stop (clean, reason) {
+        if (this.installProcess && this.state === States.INSTALLING) {
+            // If the launcher is currently installing, we should try not to interrupt this
+            // to avoid corruption (NPM can leave temporary directories preventing future installs)
+            // We should wait for the install to finish before stopping
+            // give it a few seconds to finish
+            const timeout = new Promise(resolve => setTimeout(resolve, 10000))
+            await Promise.race([this.installProcess, timeout])
+            // now proceed with stopping, regardless of whether the install finished
+        }
+        let finalState = States.STOPPED
+        this.stopReason = reason || 'shutdown'
+        info('Stopping Node-RED. Reason: ' + reason)
+        if (reason === States.SUSPENDED) {
+            finalState = States.SUSPENDED
+        }
         if (this.deferredStop) {
             // A stop request is already inflight - return the existing deferred object
             return this.deferredStop
@@ -455,10 +486,11 @@ class Launcher {
                     warn('Error cleaning instance directory', err)
                 }
             }
+            info('Node-RED Stopped')
+            await this.agent?.checkIn() // let FF know we've stopped
         }
 
         if (this.proc) {
-            this.shuttingDown = true
             // Setup a promise that will resolve once the process has really exited
             this.deferredStop = new Promise((resolve, reject) => {
                 // Setup a timeout so we can more forcefully kill Node-RED
@@ -483,17 +515,17 @@ class Launcher {
                 // allow Node-RED to shutdown cleanly. Windows looks like it does
                 // it more forcefully by default.
                 this.proc.kill()
-                this.state = 'stopped'
+                this.state = finalState
             })
             return this.deferredStop
         } else {
-            this.state = 'stopped'
+            this.state = finalState
             await postShutdownOps()
         }
     }
 }
 
 module.exports = {
-    newLauncher: (config, application, project, snapshot, settings, mode) => new Launcher(config, application, project, snapshot, settings, mode),
+    newLauncher: (agent, application, project, snapshot, settings, mode) => new Launcher(agent, application, project, snapshot, settings, mode),
     Launcher
 }

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -111,21 +111,8 @@ class MQTTClient {
                     // upload expects a response. get the data and send it back
                     const response = await this.getUploadData()
                     this.sendCommandResponse(msg, response)
-                } else if (msg.command === 'start') {
-                    info('Device start requested')
-                    const success = await this.agent.startNR()
-                    this.sendCommandResponse(msg, { success })
-                    this.agent.checkIn(3, 1000) // attempt a check in (3 retries, 1s interval)
-                } else if (msg.command === 'restart') {
-                    info('Device restart requested')
-                    const success = await this.agent.restartNR()
-                    this.sendCommandResponse(msg, { success })
-                    this.agent.checkIn(3, 1000) // attempt a check in (3 retries, 1s interval)
-                } else if (msg.command === 'suspend') {
-                    info('Device suspend requested')
-                    const success = await this.agent.suspendNR()
-                    this.sendCommandResponse(msg, { success })
-                    this.agent.checkIn(3, 1000) // attempt a check in (3 retries, 1s interval)
+                } else if (msg.command === 'action') {
+                    await this.handleActionRequest(msg)
                 } else {
                     warn(`Unknown command type received from platform: ${msg.command}`)
                 }
@@ -144,6 +131,51 @@ class MQTTClient {
         this.heartbeat.start({ interval: period * 1000, jitter: jitter * 1000, firstInterval: 10, firstJitter: 500 }, () => {
             this.checkIn()
         })
+    }
+
+    /**
+     * Perform a device action of starting, restarting or suspending the Node-RED instance
+     * @param {Object} msg - the incoming message data
+     */
+    async handleActionRequest (msg) {
+        const action = msg?.payload?.action || ''
+        try {
+            let result = false
+            let error = null
+            switch (action) {
+            case 'start':
+                info('Node-RED start requested')
+                result = await this.agent.startNR()
+                break
+            case 'restart':
+                info('Node-RED restart requested')
+                result = await this.agent.restartNR()
+                break
+            case 'suspend':
+                info('Node-RED suspend requested')
+                result = await this.agent.suspendNR()
+                break
+            default:
+                error = new Error(`Unsupported action requested: ${action}`)
+                error.code = 'unsupported_action'
+                throw error
+            }
+            if (result) {
+                this.sendCommandResponse(msg, { success: result })
+            } else {
+                throw new Error('Requested action ' + action + ' failed')
+            }
+        } catch (err) {
+            warn(err.toString())
+            debug(err)
+            const error = {
+                message: err.toString(),
+                code: err.code || 'unexpected_error',
+                error: err.message || 'Unexpected error'
+            }
+            this.sendCommandResponse(msg, { success: false, error })
+        }
+        this.agent.checkIn(3, 1000) // attempt a check in (3 retries, 1s interval)
     }
 
     stop () {

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -89,19 +89,15 @@ class MQTTClient {
                         this.initialCheckinTimeout = null
                     }
                     await this.agent.setState(msg)
-                    return
                 } else if (msg.command === 'startLog') {
                     if (!this.logEnabled) {
                         this.client.publish(this.logTopic, JSON.stringify(getBufferedMessages()))
                     }
                     this.logEnabled = true
-                    return
                 } else if (msg.command === 'stopLog') {
                     this.logEnabled = false
-                    return
                 } else if (msg.command === 'startEditor') {
                     await this.startTunnel(msg.payload?.token, this.agent.editorAffinity || null, msg)
-                    return
                 } else if (msg.command === 'stopEditor') {
                     // Clear the saved token
                     await this.saveEditorToken(null, null)
@@ -110,15 +106,29 @@ class MQTTClient {
                         this.tunnel.close()
                         this.tunnel = null
                     }
-                    return
                 } else if (msg.command === 'upload') {
                     info('Capturing device snapshot')
                     // upload expects a response. get the data and send it back
                     const response = await this.getUploadData()
                     this.sendCommandResponse(msg, response)
-                    return
+                } else if (msg.command === 'start') {
+                    info('Device start requested')
+                    const success = await this.agent.startNR()
+                    this.sendCommandResponse(msg, { success })
+                    this.agent.checkIn(3, 1000) // attempt a check in (3 retries, 1s interval)
+                } else if (msg.command === 'restart') {
+                    info('Device restart requested')
+                    const success = await this.agent.restartNR()
+                    this.sendCommandResponse(msg, { success })
+                    this.agent.checkIn(3, 1000) // attempt a check in (3 retries, 1s interval)
+                } else if (msg.command === 'suspend') {
+                    info('Device suspend requested')
+                    const success = await this.agent.suspendNR()
+                    this.sendCommandResponse(msg, { success })
+                    this.agent.checkIn(3, 1000) // attempt a check in (3 retries, 1s interval)
+                } else {
+                    warn(`Unknown command type received from platform: ${msg.command}`)
                 }
-                warn(`Unknown command type received from platform: ${msg.command}`)
             } catch (err) {
                 warn(err)
                 warn(`Invalid command message received from platform: ${_message}`)
@@ -143,7 +153,11 @@ class MQTTClient {
         }
         info('Closing MQTT connection')
         setMQTT(undefined)
-        this.client && this.client.end()
+        if (this.client) {
+            this.setApplication(null) // unsubscribe from application commands
+            this.setProject(null) // unsubscribe from application commands
+            this.client.end()
+        }
     }
 
     checkIn () {

--- a/lib/states.js
+++ b/lib/states.js
@@ -1,21 +1,3 @@
-/**
- * @typedef {Object} States
- * @property {string} UNKNOWN - not a state nr-launcher supports (unique to nr-device-agent)
- * @property {string} UPDATING - not a state nr-launcher supports (unique to nr-device-agent)
- * @property {string} PROVISIONING - not a state nr-launcher supports (unique to nr-device-agent)
- * @property {string} SUSPENDED - not a state nr-launcher supports (unique to nr-device-agent)
- * @property {string} STOPPED
- * @property {string} LOADING
- * @property {string} INSTALLING
- * @property {string} STARTING
- * @property {string} RUNNING
- * @property {string} SAFE
- * @property {string} CRASHED
- * @property {string} STOPPING
- * @property {string} ERROR - not a state nr-launcher supports (unique to nr-device-agent)
- */
-
-/** @type {States} */
 const States = {
     UNKNOWN: 'unknown',
     UPDATING: 'updating',
@@ -25,6 +7,7 @@ const States = {
     LOADING: 'loading',
     INSTALLING: 'installing',
     STARTING: 'starting',
+    RESTARTING: 'restarting',
     RUNNING: 'running',
     SAFE: 'safe',
     CRASHED: 'crashed',
@@ -33,7 +16,7 @@ const States = {
 }
 
 const TargetStates = [States.RUNNING, States.SUSPENDED]
-const TransitionStates = [States.LOADING, States.INSTALLING, States.STARTING, States.STOPPING, States.UPDATING]
+const TransitionStates = [States.LOADING, States.INSTALLING, States.STARTING, States.STOPPING, States.UPDATING, States.RESTARTING, States.PROVISIONING]
 
 /**
  * Checks if a state is valid.

--- a/lib/states.js
+++ b/lib/states.js
@@ -1,0 +1,73 @@
+/**
+ * @typedef {Object} States
+ * @property {string} UNKNOWN - not a state nr-launcher supports (unique to nr-device-agent)
+ * @property {string} UPDATING - not a state nr-launcher supports (unique to nr-device-agent)
+ * @property {string} PROVISIONING - not a state nr-launcher supports (unique to nr-device-agent)
+ * @property {string} SUSPENDED - not a state nr-launcher supports (unique to nr-device-agent)
+ * @property {string} STOPPED
+ * @property {string} LOADING
+ * @property {string} INSTALLING
+ * @property {string} STARTING
+ * @property {string} RUNNING
+ * @property {string} SAFE
+ * @property {string} CRASHED
+ * @property {string} STOPPING
+ * @property {string} ERROR - not a state nr-launcher supports (unique to nr-device-agent)
+ */
+
+/** @type {States} */
+const States = {
+    UNKNOWN: 'unknown',
+    UPDATING: 'updating',
+    PROVISIONING: 'provisioning',
+    SUSPENDED: 'suspended',
+    STOPPED: 'stopped',
+    LOADING: 'loading',
+    INSTALLING: 'installing',
+    STARTING: 'starting',
+    RUNNING: 'running',
+    SAFE: 'safe',
+    CRASHED: 'crashed',
+    STOPPING: 'stopping',
+    ERROR: 'error'
+}
+
+const TargetStates = [States.RUNNING, States.SUSPENDED]
+const TransitionStates = [States.LOADING, States.INSTALLING, States.STARTING, States.STOPPING, States.UPDATING]
+
+/**
+ * Checks if a state is valid.
+ *
+ * @param {string} state - The state to check.
+ * @returns {boolean} True if the state is valid, false otherwise.
+ */
+function isValidState (state) {
+    return Object.values(States).includes(state)
+}
+
+/**
+ * Checks if a target state is valid.
+ *
+ * @param {string} state - The state to check.
+ * @returns {boolean} True if the target state is valid, false otherwise.
+ */
+function isTargetState (state) {
+    return TargetStates.includes(state)
+}
+
+/**
+ * Checks if a transition state is valid.
+ *
+ * @param {string} state - The state to check.
+ * @returns {boolean} True if the transition state is valid, false otherwise.
+ */
+function isTransitionState (state) {
+    return TransitionStates.includes(state)
+}
+
+module.exports = {
+    States,
+    isValidState,
+    isTargetState,
+    isTransitionState
+}

--- a/test/unit/lib/launcher_spec.js
+++ b/test/unit/lib/launcher_spec.js
@@ -34,7 +34,7 @@ describe('Launcher', function () {
     })
 
     it('Create Snapshot Flow/Creds Files, instance bound device', async function () {
-        const launcher = newLauncher(config, null, 'projectId', setup.snapshot)
+        const launcher = newLauncher({ config }, null, 'projectId', setup.snapshot)
         await launcher.writeFlow()
         await launcher.writeCredentials()
         const flow = await fs.readFile(path.join(config.dir, 'project', 'flows.json'))
@@ -44,7 +44,7 @@ describe('Launcher', function () {
     })
 
     it('Create Snapshot Flow/Creds Files, application bound device', async function () {
-        const launcher = newLauncher(config, 'applicationId', null, setup.snapshot)
+        const launcher = newLauncher({ config }, 'applicationId', null, setup.snapshot)
         await launcher.writeFlow()
         await launcher.writeCredentials()
         const flow = await fs.readFile(path.join(config.dir, 'project', 'flows.json'))
@@ -54,7 +54,7 @@ describe('Launcher', function () {
     })
 
     it('Write Settings - without broker, instance bound device', async function () {
-        const launcher = newLauncher(config, null, 'PROJECTID', setup.snapshot)
+        const launcher = newLauncher({ config }, null, 'PROJECTID', setup.snapshot)
         await launcher.writeSettings()
         const setFile = await fs.readFile(path.join(config.dir, 'project', 'settings.json'))
         const settings = JSON.parse(setFile)
@@ -65,7 +65,7 @@ describe('Launcher', function () {
         settings.flowforge.should.not.have.property('projectLink')
     })
     it('Write Settings - without broker, application bound device', async function () {
-        const launcher = newLauncher(config, 'APP-ID', null, setup.snapshot)
+        const launcher = newLauncher({ config }, 'APP-ID', null, setup.snapshot)
         await launcher.writeSettings()
         const setFile = await fs.readFile(path.join(config.dir, 'project', 'settings.json'))
         const settings = JSON.parse(setFile)
@@ -77,10 +77,12 @@ describe('Launcher', function () {
     })
     it('Write Settings - with broker', async function () {
         const launcher = newLauncher({
-            ...config,
-            brokerURL: 'BURL',
-            brokerUsername: 'BUSER:TEAMID:deviceid',
-            brokerPassword: 'BPASS'
+            config: {
+                ...config,
+                brokerURL: 'BURL',
+                brokerUsername: 'BUSER:TEAMID:deviceid',
+                brokerPassword: 'BPASS'
+            }
         }, null, 'PROJECTID', setup.snapshot)
         await launcher.writeSettings()
         const setFile = await fs.readFile(path.join(config.dir, 'project', 'settings.json'))
@@ -98,7 +100,7 @@ describe('Launcher', function () {
     })
 
     it('Write package.json', async function () {
-        const launcher = newLauncher(config, null, 'projectId', setup.snapshot)
+        const launcher = newLauncher({ config }, null, 'projectId', setup.snapshot)
         await launcher.writePackage()
         const pkgFile = await fs.readFile(path.join(config.dir, 'project', 'package.json'))
         const pkg = JSON.parse(pkgFile)
@@ -110,11 +112,13 @@ describe('Launcher', function () {
 
     it('Write Settings - with HTTPS, raw values', async function () {
         const launcher = newLauncher({
-            ...config,
-            https: {
-                cert: '123',
-                ca: '456',
-                key: '789'
+            config: {
+                ...config,
+                https: {
+                    cert: '123',
+                    ca: '456',
+                    key: '789'
+                }
             }
         }, null, 'PROJECTID', setup.snapshot)
         await launcher.writeSettings()
@@ -124,8 +128,10 @@ describe('Launcher', function () {
     })
     it('Write Settings - with httpStatic', async function () {
         const launcher = newLauncher({
-            ...config,
-            httpStatic: 'static-path'
+            config: {
+                ...config,
+                httpStatic: 'static-path'
+            }
         }, null, 'PROJECTID', setup.snapshot)
         await launcher.writeSettings()
         const setFile = await fs.readFile(path.join(config.dir, 'project', 'settings.json'))
@@ -133,13 +139,13 @@ describe('Launcher', function () {
         settings.should.have.property('httpStatic', 'static-path')
     })
     it('Write .npmrc file', async function () {
-        const launcher = newLauncher(config, null, 'projectId', setup.snapshot)
+        const launcher = newLauncher({ config }, null, 'projectId', setup.snapshot)
         await launcher.writeNPMRCFile()
         const npmrc = await fs.readFile(path.join(config.dir, 'project', '.npmrc'))
         npmrc.toString().should.eql('// test\n')
     })
     it('Writes flowfuse theme files', async function () {
-        const launcher = newLauncher(config, null, 'projectId', setup.snapshot)
+        const launcher = newLauncher({ config }, null, 'projectId', setup.snapshot)
         await launcher.writeThemeFiles()
         const expectedTargetDir = path.join(config.dir, 'project', 'node_modules', '@flowfuse', 'nr-theme')
         const themeFiles = await fs.readdir(expectedTargetDir)
@@ -170,7 +176,7 @@ describe('Launcher', function () {
             licenseType: 'ee',
             licensed: true
         }
-        const launcher = newLauncher(licensedConfig, null, 'projectId', setup.snapshot)
+        const launcher = newLauncher({ config: licensedConfig }, null, 'projectId', setup.snapshot)
         await launcher.writeSettings()
         const setFile = await fs.readFile(path.join(config.dir, 'project', 'settings.json'))
         const settings = JSON.parse(setFile)
@@ -183,7 +189,7 @@ describe('Launcher', function () {
         settings.editorTheme.palette.catalogue[2].should.eql('baz')
     })
     it('ignores custom catalogue when NOT licensed', async function () {
-        const launcher = newLauncher(config, null, 'projectId', setup.snapshot)
+        const launcher = newLauncher({ config }, null, 'projectId', setup.snapshot)
         await launcher.writeSettings()
         const setFile = await fs.readFile(path.join(config.dir, 'project', 'settings.json'))
         const settings = JSON.parse(setFile)
@@ -192,7 +198,7 @@ describe('Launcher', function () {
         settings.editorTheme.palette.should.not.have.a.property('catalogue')
     })
     it('sets up audit logging for the node-red instance', async function () {
-        const launcher = newLauncher(configWithPlatformInfo, null, 'projectId', setup.snapshot)
+        const launcher = newLauncher({ config: configWithPlatformInfo }, null, 'projectId', setup.snapshot)
         const expectedURL = `${configWithPlatformInfo.forgeURL}/logging/device/${configWithPlatformInfo.deviceId}/audit`
         should(launcher).be.an.Object()
         launcher.should.have.property('auditLogURL', expectedURL)
@@ -207,7 +213,7 @@ describe('Launcher', function () {
         settings.flowforge.auditLogger.should.have.property('bin', path.join(__dirname, '..', '..', '..', 'lib', 'auditLogger', 'index.js'))
     })
     it('settings.js loads audit logger with settings from config', async function () {
-        const launcher = newLauncher(configWithPlatformInfo, null, 'projectId', setup.snapshot)
+        const launcher = newLauncher({ config: configWithPlatformInfo }, null, 'projectId', setup.snapshot)
         const expectedURL = `${configWithPlatformInfo.forgeURL}/logging/device/${configWithPlatformInfo.deviceId}/audit`
         await launcher.writeSettings()
 

--- a/test/unit/lib/states_spec.js
+++ b/test/unit/lib/states_spec.js
@@ -1,0 +1,50 @@
+// eslint-disable-next-line no-unused-vars
+const should = require('should')
+
+const { States, isValidState, isTargetState, isTransitionState } = require('../../../lib/states')
+
+describe('State validation', () => {
+    it('isValidState should return true for valid states', () => {
+        // just a selection of states to check the function
+        isValidState(States.RUNNING).should.be.true()
+        isValidState(States.STARTING).should.be.true()
+        isValidState(States.STOPPED).should.be.true()
+        isValidState(States.STOPPING).should.be.true()
+        isValidState(States.PROVISIONING).should.be.true()
+        isValidState(States.SUSPENDED).should.be.true()
+        isValidState(States.ERROR).should.be.true()
+        isValidState(States.UNKNOWN).should.be.true()
+        isValidState(States.SAFE).should.be.true()
+    })
+
+    it('isValidState should return false for invalid states', () => {
+        isValidState('INVALID_STATE').should.be.false()
+    })
+
+    it('isTargetState should return true for valid target states', () => {
+        isTargetState(States.RUNNING).should.be.true()
+        isTargetState(States.SUSPENDED).should.be.true()
+    })
+
+    it('isTargetState should return false for invalid target states', () => {
+        isTargetState('INVALID_STATE').should.be.false()
+        isTargetState(States.ERROR).should.be.false()
+        isTargetState(States.UNKNOWN).should.be.false()
+    })
+
+    it('isTransitionState should return true for valid transition states', () => {
+        isTransitionState(States.STARTING).should.be.true()
+        isTransitionState(States.STOPPING).should.be.true()
+        isTransitionState(States.LOADING).should.be.true()
+        isTransitionState(States.INSTALLING).should.be.true()
+        isTransitionState(States.UPDATING).should.be.true()
+    })
+
+    it('isTransitionState should return false for invalid transition states', () => {
+        isTransitionState('INVALID_STATE').should.be.false()
+        isTransitionState(States.ERROR).should.be.false()
+        isTransitionState(States.RUNNING).should.be.false()
+        isTransitionState(States.STOPPED).should.be.false()
+        isTransitionState(States.SAFE).should.be.false()
+    })
+})


### PR DESCRIPTION
## Description

* Adds new command route to `mqtt.js`: `"action"`
  * Supports "start", "suspend", "restart"
* Adds `targetState` property to the project (persisted to the project file to ensure reboots to correct target state)
   * targetState supports only "running" and "suspended" at this time
* Converted hardcoded `"state"` strings into a an enum (was getting lost with all the supported states) $ added helper functions for verifying state
* To support timely and more accurate state feedback to FF, `checkin` is now called when state changes inside the launcher (important now we have transitional state info reporting on FF and necessary for good UX on the Actions menu items availability)
* Attempts to mitigate issue when agent is busy installing modules and the launcher is stopped by awaiting the install process for a few seconds grace before forcefully stopping. This was done as I managed cause a lock ups by ill timed restarts and suspends during testing.
  * NOTE: This was a balance struck on making the device "do what it is told" vs "leaving it "stuck installing" or "stuck starting" etc. 
  * We may want to revisit and simply inhibit actions altogether while installation is occurring.

### Tests added
```
  Agent
    actions
      ✔ suspends Node-RED
      ✔ reloads target state as suspended
      ✔ reloads target state as running
      ✔ restarts Node-RED
      ✔ starts Node-RED after suspend
    getState
      ✔ returns state when suspended

  MQTT Comms
    ✔ suspend action calls agent.suspendNR and checks in (573ms)
    ✔ start action calls agent.startNR and checks in (567ms)
    ✔ restart action calls agent.restartNR and checks in (576ms)
    ✔ Invalid action responds with error (568ms)

  State validation
    ✔ isValidState should return true for valid states
    ✔ isValidState should return false for invalid states
    ✔ isTargetState should return true for valid target states
    ✔ isTargetState should return false for invalid target states
    ✔ isTransitionState should return true for valid transition states
    ✔ isTransitionState should return false for invalid transition states
```


## Related Issue(s)

https://github.com/FlowFuse/flowfuse/issues/3292

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

