### PR TITLE
Fix CORS handling

### DIFF
--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -61,6 +61,7 @@ const runtimeSettings = {
     adminAuth: auth,
     httpAdminRoot: 'device-editor',
     disableEditor: false, // permit editing of device flows as of FF v1.7.0
+    httpNodeCors: { origin: '*', methods: 'GET,PUT,POST,DELETE' },
     externalModules: {
         autoInstall: true,
         palette: {


### PR DESCRIPTION
fixes #241

## Description

<!-- Describe your changes in detail -->
Since the editor was moved to the `/device-editor` path this removed the default CORS middleware from the `httpNodeRoot` so OPTIONS calls were not handled properly.

This adds the default handler to the `httpNodeRoot` path

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#241

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

