### PR TITLE
Add catalogue and npmrc to App bound instances

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -223,8 +223,14 @@ class Launcher {
 
         // if licensed, add palette catalogues
         if (this.config.licensed) {
-            if (this.snapshot?.settings?.palette?.catalogue !== undefined) {
-                settings.editorTheme.palette.catalogue = this.snapshot.settings.palette.catalogue
+            if (this.project) {
+                if (this.snapshot?.settings?.palette?.catalogue !== undefined) {
+                    settings.editorTheme.palette.catalogues = this.snapshot.settings.palette.catalogue
+                }
+            } else if (this.application) {
+                if (this.settings.palette?.catalogues) {
+                    settings.editorTheme.palette.catalogues = this.settings.palette.catalogues
+                }
             }
         }
 
@@ -284,11 +290,21 @@ class Launcher {
      * Write .npmrc file
      */
     async writeNPMRCFile () {
-        if (this.snapshot.settings?.palette?.npmrc) {
-            await fs.writeFile(this.files.npmrc, this.snapshot.settings.palette.npmrc)
-        } else {
-            if (existsSync(this.files.npmrc)) {
-                await fs.rm(this.files.npmrc)
+        if (this.project) {
+            if (this.snapshot.settings?.palette?.npmrc) {
+                await fs.writeFile(this.files.npmrc, this.snapshot.settings.palette.npmrc)
+            } else {
+                if (existsSync(this.files.npmrc)) {
+                    await fs.rm(this.files.npmrc)
+                }
+            }
+        } else if (this.application) {
+            if (this.settings.palette?.npmrc) {
+                await fs.writeFile(this.files.npmrc, this.settings.palette.npmrc)
+            } else {
+                if (existsSync(this.files.npmrc)) {
+                    await fs.rm(this.files.npmrc)
+                }
             }
         }
     }
@@ -312,6 +328,7 @@ class Launcher {
         }
         if (!options || options.updateSettings === true) {
             await this.writeSettings()
+            await this.writeNPMRCFile()
         }
     }
 

--- a/test/unit/lib/launcher_spec.js
+++ b/test/unit/lib/launcher_spec.js
@@ -210,7 +210,7 @@ describe('Launcher', function () {
         const settings = JSON.parse(setFile)
         settings.should.have.property('editorTheme')
         settings.editorTheme.should.have.property('palette')
-        settings.editorTheme.palette.should.have.a.property('catalogue').and.be.an.Array()
+        settings.editorTheme.palette.should.have.a.property('catalogues').and.be.an.Array()
         settings.editorTheme.palette.catalogues.should.have.a.lengthOf(3)
         settings.editorTheme.palette.catalogues[0].should.eql('foo')
         settings.editorTheme.palette.catalogues[1].should.eql('bar')

--- a/test/unit/lib/launcher_spec.js
+++ b/test/unit/lib/launcher_spec.js
@@ -211,10 +211,10 @@ describe('Launcher', function () {
         settings.should.have.property('editorTheme')
         settings.editorTheme.should.have.property('palette')
         settings.editorTheme.palette.should.have.a.property('catalogue').and.be.an.Array()
-        settings.editorTheme.palette.catalogue.should.have.a.lengthOf(3)
-        settings.editorTheme.palette.catalogue[0].should.eql('foo')
-        settings.editorTheme.palette.catalogue[1].should.eql('bar')
-        settings.editorTheme.palette.catalogue[2].should.eql('baz')
+        settings.editorTheme.palette.catalogues.should.have.a.lengthOf(3)
+        settings.editorTheme.palette.catalogues[0].should.eql('foo')
+        settings.editorTheme.palette.catalogues[1].should.eql('bar')
+        settings.editorTheme.palette.catalogues[2].should.eql('baz')
     })
     it('ignores custom catalogue when NOT licensed', async function () {
         const launcher = newLauncher({ config }, null, 'projectId', setup.snapshot)
@@ -223,7 +223,7 @@ describe('Launcher', function () {
         const settings = JSON.parse(setFile)
         settings.should.have.property('editorTheme')
         settings.editorTheme.should.have.property('palette')
-        settings.editorTheme.palette.should.not.have.a.property('catalogue')
+        settings.editorTheme.palette.should.not.have.a.property('catalogues')
     })
     it('sets up audit logging for the node-red instance', async function () {
         const launcher = newLauncher({ config: configWithPlatformInfo }, null, 'projectId', setup.snapshot)


### PR DESCRIPTION
Part of https://github.com/FlowFuse/flowfuse/issues/3588
## Description

<!-- Describe your changes in detail -->
Allows catalogue.json URLs and .npmrc to be set for a Application bound Device

Paired with https://github.com/FlowFuse/flowfuse/pull/3643

## Related Issue(s)

<!-- What issue does this PR relate to? -->
https://github.com/FlowFuse/flowfuse/issues/3588

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

