### PR TITLE
Remove Object.hasOwn

### DIFF
--- a/lib/logging/log.js
+++ b/lib/logging/log.js
@@ -1,4 +1,5 @@
 const LogBuffer = require('./logBuffer')
+const { hasProperty } = require('../utils')
 
 let buffer
 let mqtt
@@ -21,11 +22,11 @@ function NRlog (msg) {
     let jsMsg
     try {
         jsMsg = JSON.parse(msg)
+        if (!hasProperty(jsMsg, 'ts') && !hasProperty(jsMsg, 'level')) {
+            // not a NR log message
+            jsMsg = { ts: Date.now(), level: '', msg }
+        }
     } catch (eee) {
-        jsMsg = { ts: Date.now(), level: '', msg }
-    }
-    if (!Object.hasOwn(jsMsg, 'ts') && !Object.hasOwn(jsMsg, 'level')) {
-        // not a NR log message
         jsMsg = { ts: Date.now(), level: '', msg }
     }
     const date = new Date(jsMsg.ts)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -73,7 +73,7 @@ function isObject (object) {
 }
 
 /**
- * Test if an object has a property
+ * Test if an object has a property - Node 14 friendly version of Object.hasOwn
  * @param {Object} object - an object to check for a property
  * @param {String} property - the name of the property to check for
  * @returns `true` if the object has the property, `false` otherwise

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
         "lint": "eslint -c .eslintrc \"*.js\" \"lib/**/*.js\" \"frontend/**/*.js\" \"frontend/**/*.html\" \"test/**/*.js\"",
         "lint:fix": "eslint -c .eslintrc \"*.js\" \"lib/**/*.js\" \"frontend/**/*.js\" \"frontend/**/*.html\" \"test/**/*.js\" --fix",
         "test": "npm run test:lib && npm run test:frontend",
-        "test:lib": "mocha test/unit/**/*_spec.js",
-        "test:frontend": "mocha test/unit/frontend/**/*.spec.js"
+        "test:lib": "mocha 'test/unit/**/*_spec.js'",
+        "test:frontend": "mocha 'test/unit/frontend/**/*.spec.js'"
     },
     "bin": {
         "flowforge-device-agent": "./index.js",

--- a/test/unit/lib/logging/log_spec.js
+++ b/test/unit/lib/logging/log_spec.js
@@ -29,12 +29,7 @@ describe('Log', function () {
                 msg: 'm5'
             }))
             Log.info('m6')
-            Log.NRlog(JSON.stringify({
-                level: 'info',
-                ts: Date.now(),
-                msg: 'm7'
-            }))
-
+            Log.NRlog('m7')
             const bufferedMessages = Log.getBufferedMessages()
             // Verify we buffered the last 5
             bufferedMessages.should.have.length(5)


### PR DESCRIPTION
To keep Node 14 support going, we cannot use Object.hasOwn. A couple instances crept in recently that were not caught by our unit tests.

Curiously, we have unit tests in this area and we run tests with Node 14. But on closer inspection, the glob used to run tests was missing quotes. This meant it wasn't getting evaluated properly and failed to include any _spec files nests two levels down. The only such spec file was the logging file that would have caught this error.

Have removed the hasOwn and updated the test command to ensure all tests get run