### PR TITLE
If NR process has exited, dont send or wait for sigxxx

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -525,7 +525,7 @@ class Launcher {
             await this.agent?.checkIn() // let FF know we've stopped
         }
 
-        if (this.proc) {
+        if (this.proc && this.proc.exitCode === null) {
             // Setup a promise that will resolve once the process has really exited
             this.deferredStop = new Promise((resolve, reject) => {
                 // Setup a timeout so we can more forcefully kill Node-RED

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -554,6 +554,8 @@ class Launcher {
             })
             return this.deferredStop
         } else {
+            this.proc && this.proc.unref()
+            this.proc = undefined
             this.state = finalState
             await postShutdownOps()
         }


### PR DESCRIPTION
closes #251

## Description

Skip the deferred stop if the NR process has already exited.

According to node docs:

> `subprocess.exitCode`
`integer`
The `subprocess.exitCode` property indicates the exit code of the child process. If the child process is still running, the field will be null.

Therefore this PR adds a check for exit code. If `null`, it skips the deferred stop, performs the on-stop operations, clean up (unref and null) the process & resolves immediately.


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

