### PR TITLE
Update `package.json` with user defined node-red version

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -316,9 +316,28 @@ class Launcher {
      * @param {boolean} options.updateSettings Update the settings (settings.js, settings.json)
      */
     async writeConfiguration (options = { updateSnapshot: true, updateSettings: true }) {
+        let fullWrite = !options // default to full write if no options are provided
+
+        // If this is an application owned device, the NR version might be user defined.
+        // When the updateSettings flag is set, the user defined version is specified
+        // and the versions differ, set the fullWrite flag to cause the package.json
+        // to be updated and the installDependencies function to be run.
+        const userDefinedNRVersion = this.settings?.editor?.nodeRedVersion
+        if (userDefinedNRVersion && options?.updateSettings && this.agent?.currentOwnerType === 'application') {
+            const pkg = await this.readPackage()
+            const pkgNRVersion = pkg.modules?.['node-red'] || 'latest'
+            const snapshotNRVersion = this.snapshot?.modules?.['node-red']
+            if ((pkgNRVersion !== userDefinedNRVersion || snapshotNRVersion !== userDefinedNRVersion)) {
+                // package.json dependencies will be updated with snapshot.modules when writePackage is called
+                // so here, we need to update the snapshot modules node-red version with the user defined version
+                this.snapshot.modules['node-red'] = userDefinedNRVersion
+                fullWrite = true
+            }
+        }
+
         info('Updating configuration files')
         await fs.mkdir(this.projectDir, { recursive: true })
-        if (!options || options.updateSnapshot) {
+        if (fullWrite || options.updateSnapshot) {
             this.state = States.INSTALLING
             await this.writeNPMRCFile()
             await this.writePackage()
@@ -326,7 +345,7 @@ class Launcher {
             await this.writeFlow()
             await this.writeCredentials()
         }
-        if (!options || options.updateSettings === true) {
+        if (fullWrite || options.updateSettings === true) {
             await this.writeSettings()
             await this.writeNPMRCFile()
         }


### PR DESCRIPTION
**NOTE: Part 2 of 2. Only merge when both this and the [flowfuse counterpart](https://github.com/FlowFuse/flowfuse/pull/3766) are both approved.**

## Description

As per [Solutions option 2](https://github.com/FlowFuse/flowfuse/issues/2802#issuecomment-2071738509) in issue discussion:

> Update the `writeConfiguration` logic in the Device agent to notice when `editor.noderedVersion` has been provided and update the package.json / call installDependencies


## Related Issue(s)

https://github.com/FlowFuse/flowfuse/issues/2802

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

