### PR TITLE
Ensure local ws connections are closed on disconnect

### DIFF
--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -26,7 +26,7 @@ class EditorTunnel {
 
         // How long to wait before attempting to reconnect. Start at 500ms - back
         // off if connect fails
-        this.reconnectDelay = 500
+        this.reconnectDelay = 1500
 
         const forgeURL = new URL(config.forgeURL)
         forgeURL.protocol = forgeURL.protocol === 'http:' ? 'ws:' : 'wss:'
@@ -86,7 +86,7 @@ class EditorTunnel {
             unexpectedPacketMonitor = 0
             info('Editor tunnel connected')
             // Reset reconnectDelay
-            this.reconnectDelay = 500
+            this.reconnectDelay = 1500
             this.socket.on('message', async (message) => {
                 // a message coming over the tunnel from a remote editor
                 const request = JSON.parse(message.toString('utf-8'))
@@ -261,12 +261,8 @@ class EditorTunnel {
                 // Assume we need to be reconnecting. If this close is due
                 // to a request from the platform to turn off editor access,
                 // .close will get called
-                const reconnectDelay = this.reconnectDelay
-                // Bump the delay for next time... 500ms, 1.5s, 4.5s, 10s 10s 10s...
-                this.reconnectDelay = Math.min(this.reconnectDelay * 3, 10000)
-                this.reconnectTimeout = setTimeout(() => {
-                    this.connect()
-                }, reconnectDelay)
+                this.closeLocalWebSockets()
+                this.reconnect()
             } else {
                 // A 4004/'No tunnel' response means the platform doesn't think
                 // we should be connecting - so no point retrying
@@ -274,9 +270,13 @@ class EditorTunnel {
             }
         })
         socket.on('error', (err) => {
-            warn(`Editor tunnel error: ${err}`)
-            console.warn('socket.error', err)
-            this.close(1006, err.message) // 1006 = Abnormal Closure
+            if (err.code === 'ECONNREFUSED') {
+                warn('Editor tunnel connection refused')
+            } else {
+                warn(`Editor tunnel error: ${err}`)
+                console.warn('socket.error', err)
+                this.close(1006, err.message) // 1006 = Abnormal Closure
+            }
         })
         this.socket = socket
         return !!(await this.waitForConnection())
@@ -285,11 +285,8 @@ class EditorTunnel {
     close (code, reason) {
         code = code || 1000
         reason = reason || 'Normal Closure'
-        // loop through each local comms ws client and close its connection
-        Object.keys(this.wsClients || {}).forEach(c => {
-            this.wsClients[c]?.close()
-            delete this.wsClients[c]
-        })
+
+        this.closeLocalWebSockets()
 
         // close the socket
         if (this.socket) {
@@ -334,6 +331,24 @@ class EditorTunnel {
                 }
             }, 2000)
         })
+    }
+
+    closeLocalWebSockets () {
+        // Close all ws clients to the local Node-RED
+        Object.keys(this.wsClients || {}).forEach(c => {
+            this.wsClients[c]?.close()
+            delete this.wsClients[c]
+        })
+    }
+
+    reconnect () {
+        warn(`Editor tunnel reconnecting in ${(this.reconnectDelay / 1000).toFixed(1)}s`)
+        const reconnectDelay = this.reconnectDelay
+        // Bump the delay for next time... 500ms, 1.5s, 4.5s, 10s 10s 10s...
+        this.reconnectDelay = Math.min(this.reconnectDelay * 3, 10000)
+        this.reconnectTimeout = setTimeout(() => {
+            this.connect()
+        }, reconnectDelay)
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/FlowFuse/flowfuse/issues/3751

When the device agent tunnel connection is dropped, we weren't closing down the local ws connection to Node-RED - however the platform side *does* tidy up the corresponding editor->platform connections. This meant that when the tunnel reconnects, the editors create new ws connections which in turn create new ws connections to Node-RED in the agent. This causes duplicate messages to be sent back over the proxy to the connected clients.

This fixes it by ensuring the local ws connections are closed if the tunnel closes.

Whilst debugging, it was also observed that if a tunnel fails to connect, we wouldn't retry the connection; the retry logic was only be applied if a connected socket is dropped unexpectedly.

This fixes that by not treating 'ECONNREFUSED' as a fatal error as it did before.

I've also increased the default reconnect timeout to 1.5s from 0.5s to give the remove end a bit more time to recover, with out any real impact on the user experience.