### PR TITLE
Proxy support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,11 +9,12 @@
     "extends": [
         "standard"
     ],
-    "plugins": [ "eslint-plugin-html" ],
+    "plugins": [ "eslint-plugin-html", "no-only-tests" ],
     "parserOptions": {
          "ecmaVersion": 13
     },
     "rules": {
-        "indent": ["error", 4]
+        "indent": ["error", 4],
+        "no-only-tests/no-only-tests": "error"
     }
 }

--- a/lib/AgentManager.js
+++ b/lib/AgentManager.js
@@ -2,7 +2,7 @@
 // It can start/stop and reload the agent
 
 const { initLogger, info, warn, debug } = require('./logging/log')
-const { default: got } = require('got/dist/source')
+const { default: GOT } = require('got/dist/source')
 const agent = require('./agent')
 const os = require('os')
 const fs = require('fs')
@@ -28,9 +28,7 @@ class AgentManager {
         this._state = 'unknown'
         this.agent = null
         this.configuration = null
-        this._got = got.extend({
-            agent: getHTTPProxyAgent()
-        })
+        this.client = GOT.extend({})
         return this
     }
 
@@ -192,7 +190,7 @@ class AgentManager {
             const name = ((host || ip) + (mac ? ` (${mac})` : '')) || 'New Device'
 
             // Provision this device in the forge platform and receive the device ID, credentials and other details
-            postResponse = await this._got.post(`${provisioningConfig.forgeURL}/api/v1/devices`, {
+            postResponse = await this.client.post(`${provisioningConfig.forgeURL}/api/v1/devices`, {
                 headers: {
                     'user-agent': `FlowFuse Device Agent v${this.configuration?.version || ' unknown'}`,
                     authorization: `Bearer ${provisioningConfig.token}`
@@ -200,7 +198,8 @@ class AgentManager {
                 timeout: {
                     request: 10000
                 },
-                json: { name, type, team }
+                json: { name, type, team },
+                agent: getHTTPProxyAgent(provisioningConfig.forgeURL, { timeout: 10000 })
             })
 
             if (postResponse?.statusCode !== 200) {
@@ -268,7 +267,7 @@ class AgentManager {
             // Instruct platform to re-generate credentials for this device, passing in the agentHost field and the quickConnect flag
             // NOTE: the OTC is passed in the Authorization header
             // NOTE: the OTC token is 100% single use. The platform deletes it upon use regardless of the device-agent successfully writing the config file
-            postResponse = await this._got.post(url, {
+            postResponse = await this.client.post(url, {
                 headers: {
                     'user-agent': `FlowFuse Device Agent v${this.configuration?.version || ' unknown'}`,
                     authorization: `Bearer ${provisioningConfig.token}`
@@ -276,7 +275,8 @@ class AgentManager {
                 timeout: {
                     request: 10000
                 },
-                json: { setup: true, agentHost: host || ip }
+                json: { setup: true, agentHost: host || ip },
+                agent: getHTTPProxyAgent(provisioningConfig.forgeURL, { timeout: 10000 })
             })
 
             if (postResponse?.statusCode !== 200) {
@@ -382,11 +382,12 @@ class AgentManager {
                     headers.authorization = `Bearer ${token}`
                 }
                 try {
-                    forgeCheck = await this._got.get(forgeURL, {
+                    forgeCheck = await this.client.get(forgeURL, {
                         headers,
                         timeout: {
                             request: 5000
-                        }
+                        },
+                        agent: getHTTPProxyAgent(forgeURL, { timeout: 5000 })
                     })
                     result.ip = forgeCheck?.socket?.localAddress
                     result.mac = ip2mac[result.ip] || result.ip

--- a/lib/AgentManager.js
+++ b/lib/AgentManager.js
@@ -2,14 +2,13 @@
 // It can start/stop and reload the agent
 
 const { initLogger, info, warn, debug } = require('./logging/log')
-const { default: GOT } = require('got/dist/source')
+const { default: got } = require('got/dist/source')
 const agent = require('./agent')
 const os = require('os')
 const fs = require('fs')
 const path = require('path')
 const yaml = require('yaml')
-const { HttpProxyAgent } = require('http-proxy-agent')
-const { HttpsProxyAgent } = require('https-proxy-agent')
+const { getHTTPProxyAgent } = require('./utils.js')
 
 class AgentManager {
     static options = null
@@ -29,15 +28,8 @@ class AgentManager {
         this._state = 'unknown'
         this.agent = null
         this.configuration = null
-
-        const httpProxy = process.env.http_proxy ? new HttpProxyAgent(process.env.http_proxy) : undefined
-        const httpsProxy = process.env.https_proxy ? new HttpsProxyAgent(process.env.https_proxy) : undefined
-
-        this._got = GOT.extend({
-            agent: {
-                http: httpProxy,
-                https: httpsProxy
-            }
+        this._got = got.extend({
+            agent: getHTTPProxyAgent()
         })
         return this
     }

--- a/lib/AgentManager.js
+++ b/lib/AgentManager.js
@@ -2,7 +2,7 @@
 // It can start/stop and reload the agent
 
 const { initLogger, info, warn, debug } = require('./logging/log')
-const { default: got } = require('got/dist/source')
+const { default: GOT } = require('got/dist/source')
 const agent = require('./agent')
 const os = require('os')
 const fs = require('fs')
@@ -10,7 +10,6 @@ const path = require('path')
 const yaml = require('yaml')
 const { HttpProxyAgent } = require('http-proxy-agent')
 const { HttpsProxyAgent } = require('https-proxy-agent')
-const { hasProperty } = require('./utils.js')
 
 class AgentManager {
     static options = null
@@ -31,20 +30,16 @@ class AgentManager {
         this.agent = null
         this.configuration = null
 
-        const httpProxy = hasProperty(process.env, 'http_proxy') ? new HttpProxyAgent(process.env.http_proxy) : undefined
-        const httpsProxy = hasProperty(process.env, 'https_proxy') ? new HttpsProxyAgent(process.env.https_proxy) : undefined
+        const httpProxy = process.env.http_proxy ? new HttpProxyAgent(process.env.http_proxy) : undefined
+        const httpsProxy = process.env.https_proxy ? new HttpsProxyAgent(process.env.https_proxy) : undefined
 
-        this._got = got.extend({
+        this._got = GOT.extend({
             agent: {
                 http: httpProxy,
                 https: httpsProxy
             }
         })
         return this
-    }
-
-    get got () {
-        return this._got
     }
 
     get options () {
@@ -205,7 +200,7 @@ class AgentManager {
             const name = ((host || ip) + (mac ? ` (${mac})` : '')) || 'New Device'
 
             // Provision this device in the forge platform and receive the device ID, credentials and other details
-            postResponse = await this.got.post(`${provisioningConfig.forgeURL}/api/v1/devices`, {
+            postResponse = await this._got.post(`${provisioningConfig.forgeURL}/api/v1/devices`, {
                 headers: {
                     'user-agent': `FlowFuse Device Agent v${this.configuration?.version || ' unknown'}`,
                     authorization: `Bearer ${provisioningConfig.token}`
@@ -281,7 +276,7 @@ class AgentManager {
             // Instruct platform to re-generate credentials for this device, passing in the agentHost field and the quickConnect flag
             // NOTE: the OTC is passed in the Authorization header
             // NOTE: the OTC token is 100% single use. The platform deletes it upon use regardless of the device-agent successfully writing the config file
-            postResponse = await this.got.post(url, {
+            postResponse = await this._got.post(url, {
                 headers: {
                     'user-agent': `FlowFuse Device Agent v${this.configuration?.version || ' unknown'}`,
                     authorization: `Bearer ${provisioningConfig.token}`
@@ -395,7 +390,7 @@ class AgentManager {
                     headers.authorization = `Bearer ${token}`
                 }
                 try {
-                    forgeCheck = await this.got.get(forgeURL, {
+                    forgeCheck = await this._got.get(forgeURL, {
                         headers,
                         timeout: {
                             request: 5000

--- a/lib/AgentManager.js
+++ b/lib/AgentManager.js
@@ -8,6 +8,9 @@ const os = require('os')
 const fs = require('fs')
 const path = require('path')
 const yaml = require('yaml')
+const { HttpProxyAgent } = require('http-proxy-agent')
+const { HttpsProxyAgent } = require('https-proxy-agent')
+const { hasProperty } = require('./utils.js')
 
 class AgentManager {
     static options = null
@@ -27,7 +30,21 @@ class AgentManager {
         this._state = 'unknown'
         this.agent = null
         this.configuration = null
+
+        const httpProxy = hasProperty(process.env, 'http_proxy') ? new HttpProxyAgent(process.env.http_proxy) : undefined
+        const httpsProxy = hasProperty(process.env, 'https_proxy') ? new HttpsProxyAgent(process.env.https_proxy) : undefined
+
+        this._got = got.extend({
+            agent: {
+                http: httpProxy,
+                https: httpsProxy
+            }
+        })
         return this
+    }
+
+    get got () {
+        return this._got
     }
 
     get options () {
@@ -188,7 +205,7 @@ class AgentManager {
             const name = ((host || ip) + (mac ? ` (${mac})` : '')) || 'New Device'
 
             // Provision this device in the forge platform and receive the device ID, credentials and other details
-            postResponse = await got.post(`${provisioningConfig.forgeURL}/api/v1/devices`, {
+            postResponse = await this.got.post(`${provisioningConfig.forgeURL}/api/v1/devices`, {
                 headers: {
                     'user-agent': `FlowFuse Device Agent v${this.configuration?.version || ' unknown'}`,
                     authorization: `Bearer ${provisioningConfig.token}`
@@ -264,7 +281,7 @@ class AgentManager {
             // Instruct platform to re-generate credentials for this device, passing in the agentHost field and the quickConnect flag
             // NOTE: the OTC is passed in the Authorization header
             // NOTE: the OTC token is 100% single use. The platform deletes it upon use regardless of the device-agent successfully writing the config file
-            postResponse = await got.post(url, {
+            postResponse = await this.got.post(url, {
                 headers: {
                     'user-agent': `FlowFuse Device Agent v${this.configuration?.version || ' unknown'}`,
                     authorization: `Bearer ${provisioningConfig.token}`
@@ -378,7 +395,7 @@ class AgentManager {
                     headers.authorization = `Bearer ${token}`
                 }
                 try {
-                    forgeCheck = await got.get(forgeURL, {
+                    forgeCheck = await this.got.get(forgeURL, {
                         headers,
                         timeout: {
                             request: 5000

--- a/lib/auditLogger/index.js
+++ b/lib/auditLogger/index.js
@@ -3,22 +3,27 @@
  */
 
 const { default: GOT } = require('got')
-const { HttpProxyAgent } = require('http-proxy-agent')
-const { HttpsProxyAgent } = require('https-proxy-agent')
+
+const getProxyAgent = () => {
+    const agent = {}
+    if (process.env.http_proxy) {
+        const HttpAgent = require('http-proxy-agent').HttpProxyAgent
+        agent.http = new HttpAgent(process.env.http_proxy, { timeout: 2000 })
+    }
+    if (process.env.https_proxy) {
+        const HttpsAgent = require('https-proxy-agent').HttpsProxyAgent
+        agent.https = new HttpsAgent(process.env.https_proxy, { timeout: 2000 })
+    }
+    return agent
+}
+
+const got = GOT.extend({
+    agent: getProxyAgent()
+})
 
 module.exports = (settings) => {
     const loggingURL = settings.loggingURL
     const token = settings.token
-
-    const httpProxy = process.env.http_proxy ? new HttpProxyAgent(process.env.http_proxy) : undefined
-    const httpsProxy = process.env.https_proxy ? new HttpsProxyAgent(process.env.https_proxy) : undefined
-
-    const got = GOT.extend({
-        agent: {
-            http: httpProxy,
-            https: httpsProxy
-        }
-    })
 
     const logger = function (msg) {
         if (/^(comms\.|.*\.get$)/.test(msg.event)) {

--- a/lib/auditLogger/index.js
+++ b/lib/auditLogger/index.js
@@ -39,7 +39,7 @@ module.exports = (settings) => {
     const loggingURL = settings.loggingURL
     const token = settings.token
 
-    if (process.env.https_proxy || process.env.http_proxy) {
+    if (process.env.all_proxy || process.env.https_proxy || process.env.http_proxy) {
         got = GOT.extend({
             agent: getHTTPProxyAgent(loggingURL)
         })

--- a/lib/auditLogger/index.js
+++ b/lib/auditLogger/index.js
@@ -1,29 +1,49 @@
 /*
  * The below code should be kept in-sync with nr-launcher/lib/auditLogger/index.js
+ * NOTE: The proxy agent is specific to the device-agent at this time
  */
 
 const { default: GOT } = require('got')
 
-const getProxyAgent = () => {
+/**
+ * Get proxy agent for HTTP or HTTPS got instance. This should be applied to the `agent` property of the got instance options
+ *
+ * NOTE: This utility function is specifically designed for the GOT instances where the proxy is set based on the `url`
+ *       that the instance will use to make requests. As such, the proxy URL is determined based on the `httpEndPoint` provided
+ *       in conjunction with env vars `http_proxy`, `https_proxy` and `no_proxy`.
+ * @param {String} url - http or https URL
+ * @param {import('http').AgentOptions} proxyOptions - proxy options
+ * @returns {{http: import('http-proxy-agent').HttpProxyAgent | undefined, https: import('https-proxy-agent').HttpsProxyAgent | undefined}}
+ */
+function getHTTPProxyAgent (url, proxyOptions) {
     const agent = {}
-    if (process.env.http_proxy) {
-        const HttpAgent = require('http-proxy-agent').HttpProxyAgent
-        agent.http = new HttpAgent(process.env.http_proxy, { timeout: 2000 })
-    }
-    if (process.env.https_proxy) {
-        const HttpsAgent = require('https-proxy-agent').HttpsProxyAgent
-        agent.https = new HttpsAgent(process.env.https_proxy, { timeout: 2000 })
+    if (url) {
+        const _url = new URL(url)
+        const proxyFromEnv = require('proxy-from-env')
+        const proxyUrl = proxyFromEnv.getProxyForUrl(url)
+        if (proxyUrl && _url.protocol === 'http:') {
+            const HttpAgent = require('http-proxy-agent').HttpProxyAgent
+            agent.http = new HttpAgent(proxyUrl, proxyOptions)
+        }
+        if (proxyUrl && _url.protocol === 'https:') {
+            const HttpsAgent = require('https-proxy-agent').HttpsProxyAgent
+            agent.https = new HttpsAgent(proxyUrl, proxyOptions)
+        }
     }
     return agent
 }
 
-const got = GOT.extend({
-    agent: getProxyAgent()
-})
+let got = GOT.extend({})
 
 module.exports = (settings) => {
     const loggingURL = settings.loggingURL
     const token = settings.token
+
+    if (process.env.https_proxy || process.env.http_proxy) {
+        got = GOT.extend({
+            agent: getHTTPProxyAgent(loggingURL)
+        })
+    }
 
     const logger = function (msg) {
         if (/^(comms\.|.*\.get$)/.test(msg.event)) {

--- a/lib/auditLogger/index.js
+++ b/lib/auditLogger/index.js
@@ -2,11 +2,24 @@
  * The below code should be kept in-sync with nr-launcher/lib/auditLogger/index.js
  */
 
-const { default: got } = require('got')
+const { default: GOT } = require('got')
+const { HttpProxyAgent } = require('http-proxy-agent')
+const { HttpsProxyAgent } = require('https-proxy-agent')
 
 module.exports = (settings) => {
     const loggingURL = settings.loggingURL
     const token = settings.token
+
+    const httpProxy = process.env.http_proxy ? new HttpProxyAgent(process.env.http_proxy) : undefined
+    const httpsProxy = process.env.https_proxy ? new HttpsProxyAgent(process.env.https_proxy) : undefined
+
+    const got = GOT.extend({
+        agent: {
+            http: httpProxy,
+            https: httpsProxy
+        }
+    })
+
     const logger = function (msg) {
         if (/^(comms\.|.*\.get$)/.test(msg.event)) {
             // Ignore comms events and any .get event that is just reading data

--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -1,6 +1,8 @@
 const { info, warn, debug } = require('../logging/log')
 const WebSocket = require('ws')
-const got = require('got')
+const { default: got } = require('got')
+const { HttpProxyAgent } = require('http-proxy-agent')
+const { HttpsProxyAgent } = require('https-proxy-agent')
 
 function newWsConnection (url, /** @type {WebSocket.ClientOptions} */ options) {
     if (options) {
@@ -65,9 +67,21 @@ class EditorTunnel {
         if (this.affinity) {
             headers.cookie = `FFSESSION=${this.affinity}`
         }
-        const socket = newWsConnection(forgeWSEndpoint, {
-            headers
-        })
+
+        /** @type {WebSocket.ClientOptions} */
+        const socketOptions = { headers }
+        if (process.env.http_proxy || process.env.https_proxy) {
+            info('Detected proxy setting in the environment, setting up proxy agent for Editor Tunnel')
+            const _url = new URL(forgeWSEndpoint)
+            if (_url.protocol === 'wss:') {
+                const agent = new HttpsProxyAgent(process.env.https_proxy)
+                socketOptions.agent = agent
+            } else {
+                const agent = new HttpProxyAgent(process.env.http_proxy)
+                socketOptions.agent = agent
+            }
+        }
+        const socket = newWsConnection(forgeWSEndpoint, socketOptions)
         socket.on('upgrade', (evt) => {
             if (evt.headers && evt.headers['set-cookie']) {
                 let cookies = evt.headers['set-cookie']
@@ -231,7 +245,7 @@ class EditorTunnel {
                     }).catch(_err => {
                         // debug(`proxy [${request.method}] ${fullUrl} : error ${_err.toString()}`)
                         // ↓ useful for debugging but noisy due to .map files
-                        // console.log(_err)
+                        // console.log(fullUrl, options, _err)
                         // console.log(JSON.stringify(request))
                         if (this.socket?.readyState === WebSocket.OPEN) {
                             this.socket.send(JSON.stringify({
@@ -290,7 +304,12 @@ class EditorTunnel {
 
         // close the socket
         if (this.socket) {
-            this.socket.close()
+            try {
+                // catch and (effectively) ignore errors (don't crash on "WebSocket was closed before the connection was established")
+                this.socket.close()
+            } catch (_err) {
+                debug(`Error closing socket: ${_err.message}`)
+            }
             // Remove the event listeners so we don't trigger the reconnect
             // handling
             this.socket.removeAllListeners()

--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -1,8 +1,7 @@
 const { info, warn, debug } = require('../logging/log')
 const WebSocket = require('ws')
 const { default: got } = require('got')
-const { HttpProxyAgent } = require('http-proxy-agent')
-const { HttpsProxyAgent } = require('https-proxy-agent')
+const { getWSProxyAgent } = require('../utils')
 
 function newWsConnection (url, /** @type {WebSocket.ClientOptions} */ options) {
     if (options) {
@@ -69,17 +68,9 @@ class EditorTunnel {
         }
 
         /** @type {WebSocket.ClientOptions} */
-        const socketOptions = { headers }
-        if (process.env.http_proxy || process.env.https_proxy) {
-            info('Detected proxy setting in the environment, setting up proxy agent for Editor Tunnel')
-            const _url = new URL(forgeWSEndpoint)
-            if (_url.protocol === 'wss:') {
-                const agent = new HttpsProxyAgent(process.env.https_proxy)
-                socketOptions.agent = agent
-            } else {
-                const agent = new HttpProxyAgent(process.env.http_proxy)
-                socketOptions.agent = agent
-            }
+        const socketOptions = {
+            headers,
+            agent: getWSProxyAgent(forgeWSEndpoint)
         }
         const socket = newWsConnection(forgeWSEndpoint, socketOptions)
         socket.on('upgrade', (evt) => {

--- a/lib/http.js
+++ b/lib/http.js
@@ -1,6 +1,9 @@
 const got = require('got').default
 const { info, warn, debug } = require('./logging/log')
 const { IntervalJitter } = require('./IntervalJitter')
+const { HttpProxyAgent } = require('http-proxy-agent')
+const { HttpsProxyAgent } = require('https-proxy-agent')
+const { hasProperty } = require('./utils')
 
 class HTTPClient {
     /**
@@ -17,6 +20,9 @@ class HTTPClient {
 
         this.completedInitialCheckin = false
 
+        const httpProxy = hasProperty(process.env, 'http_proxy') ? new HttpProxyAgent(process.env.http_proxy) : undefined
+        const httpsProxy = hasProperty(process.env, 'https_proxy') ? new HttpsProxyAgent(process.env.https_proxy) : undefined
+
         this.client = got.extend({
             prefixUrl: `${this.config.forgeURL}/api/v1/devices/${this.config.deviceId}/`,
             headers: {
@@ -25,6 +31,10 @@ class HTTPClient {
             },
             timeout: {
                 request: 10000
+            },
+            agent: {
+                http: httpProxy,
+                https: httpsProxy
             }
         })
     }

--- a/lib/http.js
+++ b/lib/http.js
@@ -1,9 +1,8 @@
-const got = require('got').default
+const { default: got } = require('got')
 const { info, warn, debug } = require('./logging/log')
 const { IntervalJitter } = require('./IntervalJitter')
 const { HttpProxyAgent } = require('http-proxy-agent')
 const { HttpsProxyAgent } = require('https-proxy-agent')
-const { hasProperty } = require('./utils')
 
 class HTTPClient {
     /**
@@ -20,8 +19,8 @@ class HTTPClient {
 
         this.completedInitialCheckin = false
 
-        const httpProxy = hasProperty(process.env, 'http_proxy') ? new HttpProxyAgent(process.env.http_proxy) : undefined
-        const httpsProxy = hasProperty(process.env, 'https_proxy') ? new HttpsProxyAgent(process.env.https_proxy) : undefined
+        const httpProxy = process.env.http_proxy ? new HttpProxyAgent(process.env.http_proxy) : undefined
+        const httpsProxy = process.env.https_proxy ? new HttpsProxyAgent(process.env.https_proxy) : undefined
 
         this.client = got.extend({
             prefixUrl: `${this.config.forgeURL}/api/v1/devices/${this.config.deviceId}/`,

--- a/lib/http.js
+++ b/lib/http.js
@@ -27,7 +27,7 @@ class HTTPClient {
             timeout: {
                 request: 10000
             },
-            agent: getHTTPProxyAgent()
+            agent: getHTTPProxyAgent(this.config.forgeURL, { timeout: 10000 })
         })
     }
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -1,8 +1,7 @@
 const { default: got } = require('got')
 const { info, warn, debug } = require('./logging/log')
 const { IntervalJitter } = require('./IntervalJitter')
-const { HttpProxyAgent } = require('http-proxy-agent')
-const { HttpsProxyAgent } = require('https-proxy-agent')
+const { getHTTPProxyAgent } = require('./utils')
 
 class HTTPClient {
     /**
@@ -19,9 +18,6 @@ class HTTPClient {
 
         this.completedInitialCheckin = false
 
-        const httpProxy = process.env.http_proxy ? new HttpProxyAgent(process.env.http_proxy) : undefined
-        const httpsProxy = process.env.https_proxy ? new HttpsProxyAgent(process.env.https_proxy) : undefined
-
         this.client = got.extend({
             prefixUrl: `${this.config.forgeURL}/api/v1/devices/${this.config.deviceId}/`,
             headers: {
@@ -31,10 +27,7 @@ class HTTPClient {
             timeout: {
                 request: 10000
             },
-            agent: {
-                http: httpProxy,
-                https: httpsProxy
-            }
+            agent: getHTTPProxyAgent()
         })
     }
 

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -3,7 +3,7 @@ const { existsSync } = require('fs')
 const fs = require('fs/promises')
 const path = require('path')
 const { log, info, debug, warn, NRlog } = require('./logging/log')
-const { copyDir } = require('./utils')
+const { copyDir, hasProperty } = require('./utils')
 const { States } = require('./states')
 
 const MIN_RESTART_TIME = 10000 // 10 seconds
@@ -418,6 +418,15 @@ class Launcher {
         // Use local timezone if set, else use one from snapshot settings
         // this will be ignored on Windows as it does not use the TZ env var
         env.TZ = process.env.TZ ? process.env.TZ : this.settings?.settings?.timeZone
+
+        // Add any proxy vars found in process.env. Note, this will override
+        // any proxy settings provided by the devices settings.env
+        const proxyVars = ['http_proxy', 'https_proxy', 'no_proxy', 'all_proxy']
+        proxyVars.forEach(ev => {
+            if (hasProperty(process.env, ev)) {
+                env[ev] = process.env[ev]
+            }
+        })
 
         info('Starting Node-RED')
         this.state = States.STARTING // state may have been changed by stop() or deferredStop or Installing

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -445,8 +445,7 @@ class Launcher {
             nodePaths.push(appEnv.NODE_PATH)
         }
         nodePaths.push(path.join(path.resolve(this.projectDir), 'node_modules'))
-        nodePaths.push(path.join(require.main.path, 'node_modules'))
-        // nodePaths.push(path.join(require.main.path, '..', '..'))
+        nodePaths.push(path.join(__dirname, '..', 'node_modules'))
         appEnv.NODE_PATH = nodePaths.join(path.delimiter)
 
         const processOptions = {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -437,6 +437,18 @@ class Launcher {
             this.projectDir
         ]
 
+        // Additional include paths for node modules.
+        // library, auth and other things loaded by node-red may require additional modules explicitly installed
+        // by the device agent but not necessarily in the projects node_modules directory (e.g. the proxy agents)
+        const nodePaths = []
+        if (appEnv.NODE_PATH) {
+            nodePaths.push(appEnv.NODE_PATH)
+        }
+        nodePaths.push(path.join(path.resolve(this.projectDir), 'node_modules'))
+        nodePaths.push(path.join(require.main.path, 'node_modules'))
+        // nodePaths.push(path.join(require.main.path, '..', '..'))
+        appEnv.NODE_PATH = nodePaths.join(path.delimiter)
+
         const processOptions = {
             windowHide: true,
             env: appEnv,

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -3,8 +3,7 @@ const { info, warn, debug, setMQTT, getBufferedMessages } = require('./logging/l
 const { IntervalJitter } = require('./IntervalJitter')
 const url = require('url')
 const EditorTunnel = require('./editor/tunnel')
-const { HttpProxyAgent } = require('http-proxy-agent')
-const { HttpsProxyAgent } = require('https-proxy-agent')
+const { getWSProxyAgent } = require('./utils')
 
 class MQTTClient {
     /**
@@ -46,7 +45,6 @@ class MQTTClient {
             reconnectPeriod: 15000,
             queueQoSZero: false
         }
-
         setMQTT(this)
     }
 
@@ -64,16 +62,8 @@ class MQTTClient {
         brokerURL.hostname = _url.hostname
 
         if (process.env.http_proxy || process.env.https_proxy) {
-            info('Detected proxy setting in the environment, setting up proxy agent for MQTT')
-
-            // wsOptions.agent is expected to be an agent so we determine which type to set
-            //  (http/https) based on the target connection protocol.
-            if (_url.protocol === 'wss:') {
-                const agent = new HttpsProxyAgent(process.env.https_proxy)
-                this.brokerConfig.wsOptions = { agent }
-            } else {
-                const agent = new HttpProxyAgent(process.env.http_proxy)
-                this.brokerConfig.wsOptions = { agent }
+            this.brokerConfig.wsOptions = {
+                agent: getWSProxyAgent(this.config.brokerURL)
             }
         }
         this.client = mqtt.connect(brokerURL, this.brokerConfig)

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -61,7 +61,7 @@ class MQTTClient {
         const _url = new URL(this.config.brokerURL)
         brokerURL.hostname = _url.hostname
 
-        if (process.env.http_proxy || process.env.https_proxy) {
+        if (process.env.all_proxy || process.env.http_proxy || process.env.https_proxy) {
             this.brokerConfig.wsOptions = {
                 agent: getWSProxyAgent(this.config.brokerURL)
             }

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -3,6 +3,8 @@ const { info, warn, debug, setMQTT, getBufferedMessages } = require('./logging/l
 const { IntervalJitter } = require('./IntervalJitter')
 const url = require('url')
 const EditorTunnel = require('./editor/tunnel')
+const { HttpProxyAgent } = require('http-proxy-agent')
+const { HttpsProxyAgent } = require('https-proxy-agent')
 
 class MQTTClient {
     /**
@@ -44,6 +46,7 @@ class MQTTClient {
             reconnectPeriod: 15000,
             queueQoSZero: false
         }
+
         setMQTT(this)
     }
 
@@ -59,6 +62,20 @@ class MQTTClient {
         const brokerURL = url.parse(this.config.brokerURL)
         const _url = new URL(this.config.brokerURL)
         brokerURL.hostname = _url.hostname
+
+        if (process.env.http_proxy || process.env.https_proxy) {
+            info('Detected proxy setting in the environment, setting up proxy agent for MQTT')
+
+            // wsOptions.agent is expected to be an agent so we determine which type to set
+            //  (http/https) based on the target connection protocol.
+            if (_url.protocol === 'wss:') {
+                const agent = new HttpsProxyAgent(process.env.https_proxy)
+                this.brokerConfig.wsOptions = { agent }
+            } else {
+                const agent = new HttpProxyAgent(process.env.http_proxy)
+                this.brokerConfig.wsOptions = { agent }
+            }
+        }
         this.client = mqtt.connect(brokerURL, this.brokerConfig)
 
         this.client.on('connect', () => {

--- a/lib/plugins/node_modules/@flowforge/flowforge-library-plugin/libraryPlugin.js
+++ b/lib/plugins/node_modules/@flowforge/flowforge-library-plugin/libraryPlugin.js
@@ -6,10 +6,23 @@
       be able to access the team library.
  * NOTE
     * This is MVP & should be considered as a candidate for refactoring into a single plugin.
+    * HttpProxyAgent & HttpsProxyAgent are specific to the device-agent only
 */
 
 const { default: got } = require('got')
-const { HttpsProxyAgent } = require('https-proxy-agent')
+
+const getProxyAgent = () => {
+    const agent = {}
+    if (process.env.http_proxy) {
+        const HttpAgent = require('http-proxy-agent').HttpProxyAgent
+        agent.http = new HttpAgent(process.env.http_proxy, { timeout: 2000 })
+    }
+    if (process.env.https_proxy) {
+        const HttpsAgent = require('https-proxy-agent').HttpsProxyAgent
+        agent.https = new HttpsAgent(process.env.https_proxy, { timeout: 2000 })
+    }
+    return agent
+}
 
 module.exports = function (RED) {
     const PLUGIN_TYPE_ID = 'flowfuse-team-library'
@@ -29,8 +42,6 @@ module.exports = function (RED) {
             if (!token) {
                 throw new Error('Missing required configuration property: token')
             }
-            const httpProxy = process.env.http_proxy ? new HttpsProxyAgent(process.env.http_proxy) : undefined
-            const httpsProxy = process.env.https_proxy ? new HttpsProxyAgent(process.env.https_proxy) : undefined
 
             this._client = got.extend({
                 prefixUrl: config.baseURL + '/library/' + libraryID + '/',
@@ -41,10 +52,7 @@ module.exports = function (RED) {
                 timeout: {
                     request: 10000
                 },
-                agent: {
-                    http: httpProxy,
-                    https: httpsProxy
-                }
+                agent: getProxyAgent()
             })
         }
 

--- a/lib/plugins/node_modules/@flowforge/flowforge-library-plugin/libraryPlugin.js
+++ b/lib/plugins/node_modules/@flowforge/flowforge-library-plugin/libraryPlugin.js
@@ -9,6 +9,7 @@
 */
 
 const { default: got } = require('got')
+const { HttpsProxyAgent } = require('https-proxy-agent')
 
 module.exports = function (RED) {
     const PLUGIN_TYPE_ID = 'flowfuse-team-library'
@@ -28,6 +29,9 @@ module.exports = function (RED) {
             if (!token) {
                 throw new Error('Missing required configuration property: token')
             }
+            const httpProxy = process.env.http_proxy ? new HttpsProxyAgent(process.env.http_proxy) : undefined
+            const httpsProxy = process.env.https_proxy ? new HttpsProxyAgent(process.env.https_proxy) : undefined
+
             this._client = got.extend({
                 prefixUrl: config.baseURL + '/library/' + libraryID + '/',
                 headers: {
@@ -36,6 +40,10 @@ module.exports = function (RED) {
                 },
                 timeout: {
                     request: 10000
+                },
+                agent: {
+                    http: httpProxy,
+                    https: httpsProxy
                 }
             })
         }

--- a/lib/plugins/node_modules/@flowforge/flowforge-library-plugin/package.json
+++ b/lib/plugins/node_modules/@flowforge/flowforge-library-plugin/package.json
@@ -16,6 +16,10 @@
             "flowfuse-library": "libraryPlugin.js"
         }
     },
+    "dependencies": {
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.4"
+    },
     "engines": {
         "node": ">=14.x"
     }

--- a/lib/plugins/node_modules/@flowforge/flowforge-library-plugin/package.json
+++ b/lib/plugins/node_modules/@flowforge/flowforge-library-plugin/package.json
@@ -18,7 +18,8 @@
     },
     "dependencies": {
         "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.4"
+        "https-proxy-agent": "^7.0.4",
+        "proxy-from-env": "^1.1.0"
     },
     "engines": {
         "node": ">=14.x"

--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -9,15 +9,30 @@ settings.editorTheme.header.title = settings.editorTheme.header.title || `Device
 
 const authCache = {}
 
-const getProxyAgent = () => {
+/**
+ * Get proxy agent for HTTP or HTTPS got instance. This should be applied to the `agent` property of the got instance options
+ *
+ * NOTE: This utility function is specifically designed for the GOT instances where the proxy is set based on the `url`
+ *       that the instance will use to make requests. As such, the proxy URL is determined based on the `httpEndPoint` provided
+ *       in conjunction with env vars `http_proxy`, `https_proxy` and `no_proxy`.
+ * @param {String} url - http or https URL
+ * @param {import('http').AgentOptions} proxyOptions - proxy options
+ * @returns {{http: import('http-proxy-agent').HttpProxyAgent | undefined, https: import('https-proxy-agent').HttpsProxyAgent | undefined}}
+ */
+function getHTTPProxyAgent (url, proxyOptions) {
     const agent = {}
-    if (process.env.http_proxy) {
-        const HttpAgent = require('http-proxy-agent').HttpProxyAgent
-        agent.http = new HttpAgent(process.env.http_proxy, { timeout: 2000 })
-    }
-    if (process.env.https_proxy) {
-        const HttpsAgent = require('https-proxy-agent').HttpsProxyAgent
-        agent.https = new HttpsAgent(process.env.https_proxy, { timeout: 2000 })
+    if (url) {
+        const _url = new URL(url)
+        const proxyFromEnv = require('proxy-from-env')
+        const proxyUrl = proxyFromEnv.getProxyForUrl(url)
+        if (proxyUrl && _url.protocol === 'http:') {
+            const HttpAgent = require('http-proxy-agent').HttpProxyAgent
+            agent.http = new HttpAgent(proxyUrl, proxyOptions)
+        }
+        if (proxyUrl && _url.protocol === 'https:') {
+            const HttpsAgent = require('https-proxy-agent').HttpsProxyAgent
+            agent.https = new HttpsAgent(proxyUrl, proxyOptions)
+        }
     }
     return agent
 }
@@ -47,7 +62,7 @@ const auth = {
 
         if (!got.defaults.options.agent && (process.env.https_proxy || process.env.http_proxy)) {
             got = got.extend({
-                agent: getProxyAgent()
+                agent: getHTTPProxyAgent(settings.flowforge.forgeURL, { timeout: 2000 })
             })
         }
 

--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -67,7 +67,7 @@ const auth = {
             }
         }
 
-        if (!agentApplied && (process.env.https_proxy || process.env.http_proxy)) {
+        if (!agentApplied && (process.env.all_proxy || process.env.https_proxy || process.env.http_proxy)) {
             got = got.extend({
                 agent: getHTTPProxyAgent(settings.flowforge.forgeURL, { timeout: 2000 })
             })

--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -4,10 +4,15 @@ const themeName = editorTheme.theme || 'forge-light'
 const themeSettings = settings[themeName] || {}
 const { existsSync, readFileSync } = require('fs')
 
+const { HttpsProxyAgent } = require('https-proxy-agent')
+
 settings.editorTheme.header = settings.editorTheme.header || {}
 settings.editorTheme.header.title = settings.editorTheme.header.title || `Device: ${process.env.FF_DEVICE_NAME}`
 
 const authCache = {}
+
+/** @type {GOT} */
+let got
 
 const auth = {
     type: 'credentials', // the type of the auth
@@ -24,7 +29,20 @@ const auth = {
                 return authCache[token].result
             }
         }
-        const { default: got } = await import('got')
+
+        // load got and if required, apply proxy settings
+        if (!got) {
+            const { default: GOT } = await import('got')
+            const httpProxy = process.env.http_proxy ? new HttpsProxyAgent(process.env.http_proxy) : undefined
+            const httpsProxy = process.env.https_proxy ? new HttpsProxyAgent(process.env.https_proxy) : undefined
+            got = GOT.extend({
+                agent: {
+                    http: httpProxy,
+                    https: httpsProxy
+                }
+            })
+        }
+
         try {
             const result = await got.get(`${settings.flowforge.forgeURL}/api/v1/devices/${deviceId}/editor/token`, {
                 timeout: { request: 2000 },

--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -39,6 +39,7 @@ function getHTTPProxyAgent (url, proxyOptions) {
 
 /** @type {import('got').default} */
 let got
+let agentApplied
 
 const auth = {
     type: 'credentials', // the type of the auth
@@ -57,14 +58,21 @@ const auth = {
         }
 
         if (!got) {
-            got = (await import('got')).default
+            agentApplied = false
+            try {
+                got = (await import('got')).default
+            } catch (_error) { /* ignore */ }
+            if (!got) {
+                got = require('got').default
+            }
         }
 
-        if (!got.defaults.options.agent && (process.env.https_proxy || process.env.http_proxy)) {
+        if (!agentApplied && (process.env.https_proxy || process.env.http_proxy)) {
             got = got.extend({
                 agent: getHTTPProxyAgent(settings.flowforge.forgeURL, { timeout: 2000 })
             })
         }
+        agentApplied = true
 
         try {
             const result = await got.get(`${settings.flowforge.forgeURL}/api/v1/devices/${deviceId}/editor/token`, {

--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -4,14 +4,25 @@ const themeName = editorTheme.theme || 'forge-light'
 const themeSettings = settings[themeName] || {}
 const { existsSync, readFileSync } = require('fs')
 
-const { HttpsProxyAgent } = require('https-proxy-agent')
-
 settings.editorTheme.header = settings.editorTheme.header || {}
 settings.editorTheme.header.title = settings.editorTheme.header.title || `Device: ${process.env.FF_DEVICE_NAME}`
 
 const authCache = {}
 
-/** @type {GOT} */
+const getProxyAgent = () => {
+    const agent = {}
+    if (process.env.http_proxy) {
+        const HttpAgent = require('http-proxy-agent').HttpProxyAgent
+        agent.http = new HttpAgent(process.env.http_proxy, { timeout: 2000 })
+    }
+    if (process.env.https_proxy) {
+        const HttpsAgent = require('https-proxy-agent').HttpsProxyAgent
+        agent.https = new HttpsAgent(process.env.https_proxy, { timeout: 2000 })
+    }
+    return agent
+}
+
+/** @type {import('got').default} */
 let got
 
 const auth = {
@@ -30,16 +41,13 @@ const auth = {
             }
         }
 
-        // load got and if required, apply proxy settings
         if (!got) {
-            const { default: GOT } = await import('got')
-            const httpProxy = process.env.http_proxy ? new HttpsProxyAgent(process.env.http_proxy) : undefined
-            const httpsProxy = process.env.https_proxy ? new HttpsProxyAgent(process.env.https_proxy) : undefined
-            got = GOT.extend({
-                agent: {
-                    http: httpProxy,
-                    https: httpsProxy
-                }
+            got = (await import('got')).default
+        }
+
+        if (!got.defaults.options.agent && (process.env.https_proxy || process.env.http_proxy)) {
+            got = got.extend({
+                agent: getProxyAgent()
             })
         }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const fs = require('fs').promises
+const proxyFromEnv = require('proxy-from-env')
 
 module.exports = {
     compareNodeRedData,
@@ -118,41 +119,70 @@ async function copyDir (src, dest, { recursive = true } = {}) {
 }
 
 /**
- * Get a specific proxy agent for a WebSocket connection
- * NOTE: if the WebSocket endpoint is wss:// and there is an https_proxy set, it will return an HttpsProxyAgent
- *       if the WebSocket endpoint is ws:// and there is an http_proxy set, it will return an HttpProxyAgent
- *       otherwise it will return null
- * @param {String} wsEndPoint - WebSocket endpoint
+ * Get a specific proxy agent for a WebSocket connection. This should be applied to the `wsOptions.agent` property
+ *
+ * NOTE: This utility function is specifically designed for the MQTT instances where the proxy is set based on the http based EndPoint
+ *       that the instance will use to make a connection. As such, the proxy URL is determined based on the `wsEndPoint` provided in
+ *       conjunction with env vars `http_proxy`, `https_proxy` and `no_proxy`.
+ *
+ * More Info:
+ *   `wsOptions.agent` is expected to be an HTTP or HTTPS agent based on the request protocol
+ *   http/ws requests use env var `http_proxy` and the HttpProxyAgent
+ *   https/wss requests use env var `https_proxy` and the HttpsProxyAgent
+ *   REF: https://github.com/TooTallNate/proxy-agents/tree/main/packages/proxy-agent#maps-proxy-protocols-to-httpagent-implementations
+ *
+ * @param {String} url - WebSocket url
  * @param {import('http').AgentOptions} proxyOptions - proxy options
  * @returns {import('https-proxy-agent').HttpsProxyAgent | import('http-proxy-agent').HttpProxyAgent | null}
  */
-function getWSProxyAgent (wsEndPoint, proxyOptions) {
-    const _url = new URL(wsEndPoint)
-    if (process.env.https_proxy && _url.protocol === 'wss:') {
-        const HttpsAgent = require('https-proxy-agent').HttpsProxyAgent
-        return new HttpsAgent(process.env.https_proxy, proxyOptions)
+function getWSProxyAgent (url, proxyOptions) {
+    if (!url) {
+        return null
     }
-    if (process.env.http_proxy && _url.protocol === 'ws:') {
+    const _url = new URL(url)
+    const isHTTPBased = _url.protocol === 'ws:' || _url.protocol === 'http:'
+    const isHTTPSBased = _url.protocol === 'wss:' || _url.protocol === 'https:'
+    if (!isHTTPBased && !isHTTPSBased) {
+        return null
+    }
+
+    // replace ^ws with http so that getProxyForUrl can return the correct http*_proxy for ws/wss
+    const proxyUrl = proxyFromEnv.getProxyForUrl(url.replace(/^ws/, 'http'))
+
+    if (proxyUrl && isHTTPSBased) {
+        const HttpsAgent = require('https-proxy-agent').HttpsProxyAgent
+        return new HttpsAgent(proxyUrl, proxyOptions)
+    }
+    if (proxyUrl && isHTTPBased) {
         const HttpAgent = require('http-proxy-agent').HttpProxyAgent
-        return new HttpAgent(process.env.http_proxy, proxyOptions)
+        return new HttpAgent(proxyUrl, proxyOptions)
     }
     return null
 }
 
 /**
- * Get proxy agents for HTTP and/or HTTPS connections
+ * Get proxy agent for HTTP or HTTPS got instance. This should be applied to the `agent` property of the got instance options
+ *
+ * NOTE: This utility function is specifically designed for the GOT instances where the proxy is set based on the `httpEndPoint`
+ *       that the instance will use to make requests. As such, the proxy URL is determined based on the `httpEndPoint` provided
+ *       in conjunction with env vars `http_proxy`, `https_proxy` and `no_proxy`.
+ * @param {String} url - http or https URL
  * @param {import('http').AgentOptions} proxyOptions - proxy options
  * @returns {{http: import('http-proxy-agent').HttpProxyAgent | undefined, https: import('https-proxy-agent').HttpsProxyAgent | undefined}}
  */
-function getHTTPProxyAgent (proxyOptions) {
+function getHTTPProxyAgent (url, proxyOptions) {
     const agent = {}
-    if (process.env.http_proxy) {
-        const HttpAgent = require('http-proxy-agent').HttpProxyAgent
-        agent.http = new HttpAgent(process.env.http_proxy, proxyOptions)
-    }
-    if (process.env.https_proxy) {
-        const HttpsAgent = require('https-proxy-agent').HttpsProxyAgent
-        agent.https = new HttpsAgent(process.env.https_proxy, proxyOptions)
+    if (url) {
+        const _url = new URL(url)
+        const proxyUrl = proxyFromEnv.getProxyForUrl(url)
+        if (proxyUrl && _url.protocol === 'http:') {
+            const HttpAgent = require('http-proxy-agent').HttpProxyAgent
+            agent.http = new HttpAgent(proxyUrl, proxyOptions)
+        }
+        if (proxyUrl && _url.protocol === 'https:') {
+            const HttpsAgent = require('https-proxy-agent').HttpsProxyAgent
+            agent.https = new HttpsAgent(proxyUrl, proxyOptions)
+        }
     }
     return agent
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,7 +6,9 @@ module.exports = {
     compareObjects,
     isObject,
     hasProperty,
-    copyDir
+    copyDir,
+    getWSProxyAgent,
+    getHTTPProxyAgent
 }
 
 /**
@@ -113,4 +115,44 @@ async function copyDir (src, dest, { recursive = true } = {}) {
         }
     }
     await cp(src, dest)
+}
+
+/**
+ * Get a specific proxy agent for a WebSocket connection
+ * NOTE: if the WebSocket endpoint is wss:// and there is an https_proxy set, it will return an HttpsProxyAgent
+ *       if the WebSocket endpoint is ws:// and there is an http_proxy set, it will return an HttpProxyAgent
+ *       otherwise it will return null
+ * @param {String} wsEndPoint - WebSocket endpoint
+ * @param {import('http').AgentOptions} proxyOptions - proxy options
+ * @returns {import('https-proxy-agent').HttpsProxyAgent | import('http-proxy-agent').HttpProxyAgent | null}
+ */
+function getWSProxyAgent (wsEndPoint, proxyOptions) {
+    const _url = new URL(wsEndPoint)
+    if (process.env.https_proxy && _url.protocol === 'wss:') {
+        const HttpsAgent = require('https-proxy-agent').HttpsProxyAgent
+        return new HttpsAgent(process.env.https_proxy, proxyOptions)
+    }
+    if (process.env.http_proxy && _url.protocol === 'ws:') {
+        const HttpAgent = require('http-proxy-agent').HttpProxyAgent
+        return new HttpAgent(process.env.http_proxy, proxyOptions)
+    }
+    return null
+}
+
+/**
+ * Get proxy agents for HTTP and/or HTTPS connections
+ * @param {import('http').AgentOptions} proxyOptions - proxy options
+ * @returns {{http: import('http-proxy-agent').HttpProxyAgent | undefined, https: import('https-proxy-agent').HttpsProxyAgent | undefined}}
+ */
+function getHTTPProxyAgent (proxyOptions) {
+    const agent = {}
+    if (process.env.http_proxy) {
+        const HttpAgent = require('http-proxy-agent').HttpProxyAgent
+        agent.http = new HttpAgent(process.env.http_proxy, proxyOptions)
+    }
+    if (process.env.https_proxy) {
+        const HttpsAgent = require('https-proxy-agent').HttpsProxyAgent
+        agent.https = new HttpsAgent(process.env.https_proxy, proxyOptions)
+    }
+    return agent
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "http-proxy-agent": "^7.0.2",
                 "https-proxy-agent": "^7.0.4",
                 "mqtt": "^4.3.7",
+                "proxy-from-env": "^1.1.0",
                 "semver": "^7.3.8",
                 "ws": "^8.13.0",
                 "yaml": "^2.1.1"
@@ -3498,6 +3499,11 @@
             "engines": {
                 "node": ">= 14"
             }
+        },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "node_modules/proxy-protocol-js": {
             "version": "4.0.6",
@@ -7007,6 +7013,11 @@
                 "basic-auth-parser": "0.0.2-1",
                 "debug": "^4.3.4"
             }
+        },
+        "proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "proxy-protocol-js": {
             "version": "4.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,9 @@
                 "command-line-args": "^5.2.1",
                 "command-line-usage": "^6.1.3",
                 "got": "^11.8.6",
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.4",
                 "mqtt": "^4.3.7",
-                "proxy-agent": "^6.4.0",
                 "semver": "^7.3.8",
                 "ws": "^8.13.0",
                 "yaml": "^2.1.1"
@@ -29,8 +30,11 @@
                 "eslint": "^8.25.0",
                 "eslint-config-standard": "^17.0.0",
                 "eslint-plugin-html": "^7.1.0",
+                "eslint-plugin-no-only-tests": "^3.1.0",
                 "eslint-plugin-node": "^11.1.0",
                 "mocha": "^10.0.0",
+                "proxy": "^2.1.1",
+                "rewire": "^7.0.0",
                 "should": "^13.2.3",
                 "sinon": "^14.0.0"
             },
@@ -54,23 +58,23 @@
             }
         },
         "node_modules/@eslint-community/regexpp": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
-            "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.1.tgz",
+            "integrity": "sha512-Zm2NGpWELsQAD1xsJzGQpYfvICSsFkEpU0jxBjfdC6uNEWXcHnfs9hScFWtXVDVl+rBQJGrl4g1vcKIejpH9dA==",
             "dev": true,
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
-            "integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+            "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.5.2",
+                "espree": "^9.6.0",
                 "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
@@ -86,9 +90,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "8.43.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.43.0.tgz",
-            "integrity": "sha512-s2UHCoiXfxMvmfzqoN+vrQ84ahUSYde9qNO1MdxmoEhyHWsfmwOpFlwYV+ePJEVc7gFnATGUi376WowX1N7tFg==",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+            "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -103,13 +107,13 @@
             }
         },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.11.10",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-            "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+            "version": "0.11.14",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+            "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
             "dev": true,
             "dependencies": {
-                "@humanwhocodes/object-schema": "^1.2.1",
-                "debug": "^4.1.1",
+                "@humanwhocodes/object-schema": "^2.0.2",
+                "debug": "^4.3.1",
                 "minimatch": "^3.0.5"
             },
             "engines": {
@@ -130,9 +134,9 @@
             }
         },
         "node_modules/@humanwhocodes/object-schema": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-            "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+            "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
             "dev": true
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -232,11 +236,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/@tootallnate/quickjs-emscripten": {
-            "version": "0.23.0",
-            "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-            "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
-        },
         "node_modules/@types/cacheable-request": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
@@ -281,10 +280,16 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@ungap/structured-clone": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+            "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+            "dev": true
+        },
         "node_modules/acorn": {
-            "version": "8.9.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
-            "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
+            "version": "8.11.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -518,6 +523,30 @@
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true
         },
+        "node_modules/args": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/args/-/args-5.0.3.tgz",
+            "integrity": "sha512-h6k/zfFgusnv3i5TU08KQkVKuCPBtL/PWQbWkHUxvJrZ2nAyeaUupneemcrgn1xmqxPQsPIzwkUhOpoqPDRZuA==",
+            "dev": true,
+            "dependencies": {
+                "camelcase": "5.0.0",
+                "chalk": "2.4.2",
+                "leven": "2.1.0",
+                "mri": "1.1.4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/args/node_modules/camelcase": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+            "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/array-back": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
@@ -598,17 +627,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/ast-types": {
-            "version": "0.13.4",
-            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-            "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-            "dependencies": {
-                "tslib": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/available-typed-arrays": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -646,13 +664,11 @@
                 }
             ]
         },
-        "node_modules/basic-ftp": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-            "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
-            "engines": {
-                "node": ">=10.0.0"
-            }
+        "node_modules/basic-auth-parser": {
+            "version": "0.0.2-1",
+            "resolved": "https://registry.npmjs.org/basic-auth-parser/-/basic-auth-parser-0.0.2-1.tgz",
+            "integrity": "sha512-GFj8iVxo9onSU6BnnQvVwqvxh60UcSHJEDnIk3z4B6iOjsKSmqe+ibW0Rsz7YO7IE1HG3D3tqCNIidP46SZVdQ==",
+            "dev": true
         },
         "node_modules/binary-extensions": {
             "version": "2.2.0",
@@ -992,14 +1008,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/data-uri-to-buffer": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-            "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "node_modules/debug": {
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -1090,19 +1098,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/degenerator": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
-            "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-            "dependencies": {
-                "ast-types": "^0.13.4",
-                "escodegen": "^2.1.0",
-                "esprima": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 14"
             }
         },
         "node_modules/diff": {
@@ -1327,48 +1322,29 @@
                 "node": ">=0.8.0"
             }
         },
-        "node_modules/escodegen": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-            "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-            "dependencies": {
-                "esprima": "^4.0.1",
-                "estraverse": "^5.2.0",
-                "esutils": "^2.0.2"
-            },
-            "bin": {
-                "escodegen": "bin/escodegen.js",
-                "esgenerate": "bin/esgenerate.js"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "optionalDependencies": {
-                "source-map": "~0.6.1"
-            }
-        },
         "node_modules/eslint": {
-            "version": "8.43.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.43.0.tgz",
-            "integrity": "sha512-aaCpf2JqqKesMFGgmRPessmVKjcGXqdlAYLLC3THM8t5nBRZRQ+st5WM/hoJXkdioEXLLbXgclUpM0TXo5HX5Q==",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+            "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
-                "@eslint-community/regexpp": "^4.4.0",
-                "@eslint/eslintrc": "^2.0.3",
-                "@eslint/js": "8.43.0",
-                "@humanwhocodes/config-array": "^0.11.10",
+                "@eslint-community/regexpp": "^4.6.1",
+                "@eslint/eslintrc": "^2.1.4",
+                "@eslint/js": "8.57.0",
+                "@humanwhocodes/config-array": "^0.11.14",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
-                "ajv": "^6.10.0",
+                "@ungap/structured-clone": "^1.2.0",
+                "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
                 "debug": "^4.3.2",
                 "doctrine": "^3.0.0",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^7.2.0",
-                "eslint-visitor-keys": "^3.4.1",
-                "espree": "^9.5.2",
+                "eslint-scope": "^7.2.2",
+                "eslint-visitor-keys": "^3.4.3",
+                "espree": "^9.6.1",
                 "esquery": "^1.4.2",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
@@ -1378,7 +1354,6 @@
                 "globals": "^13.19.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.2.0",
-                "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
                 "is-path-inside": "^3.0.3",
@@ -1388,9 +1363,8 @@
                 "lodash.merge": "^4.6.2",
                 "minimatch": "^3.1.2",
                 "natural-compare": "^1.4.0",
-                "optionator": "^0.9.1",
+                "optionator": "^0.9.3",
                 "strip-ansi": "^6.0.1",
-                "strip-json-comments": "^3.1.0",
                 "text-table": "^0.2.0"
             },
             "bin": {
@@ -1619,6 +1593,15 @@
                 "eslint": ">=7.0.0"
             }
         },
+        "node_modules/eslint-plugin-no-only-tests": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.1.0.tgz",
+            "integrity": "sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==",
+            "dev": true,
+            "engines": {
+                "node": ">=5.0.0"
+            }
+        },
         "node_modules/eslint-plugin-node": {
             "version": "11.1.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
@@ -1662,9 +1645,9 @@
             }
         },
         "node_modules/eslint-scope": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
-            "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+            "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
             "dev": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
@@ -1702,9 +1685,9 @@
             }
         },
         "node_modules/eslint-visitor-keys": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-            "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1775,12 +1758,12 @@
             }
         },
         "node_modules/espree": {
-            "version": "9.5.2",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
-            "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
             "dev": true,
             "dependencies": {
-                "acorn": "^8.8.0",
+                "acorn": "^8.9.0",
                 "acorn-jsx": "^5.3.2",
                 "eslint-visitor-keys": "^3.4.1"
             },
@@ -1789,18 +1772,6 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "bin": {
-                "esparse": "bin/esparse.js",
-                "esvalidate": "bin/esvalidate.js"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/esquery": {
@@ -1831,6 +1802,7 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -1839,6 +1811,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -1996,19 +1969,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/fs-extra": {
-            "version": "11.2.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.14"
-            }
-        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2119,20 +2079,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/get-uri": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
-            "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
-            "dependencies": {
-                "basic-ftp": "^5.0.2",
-                "data-uri-to-buffer": "^6.0.2",
-                "debug": "^4.3.4",
-                "fs-extra": "^11.2.0"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "node_modules/glob": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -2165,9 +2111,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "13.20.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-            "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+            "version": "13.24.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
             "dev": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -2231,11 +2177,6 @@
             "funding": {
                 "url": "https://github.com/sindresorhus/got?sponsor=1"
             }
-        },
-        "node_modules/graceful-fs": {
-            "version": "4.2.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
         },
         "node_modules/graphemer": {
             "version": "1.4.0",
@@ -2506,18 +2447,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/ip-address": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-            "dependencies": {
-                "jsbn": "1.1.0",
-                "sprintf-js": "^1.1.3"
-            },
-            "engines": {
-                "node": ">= 12"
             }
         },
         "node_modules/is-array-buffer": {
@@ -2844,11 +2773,6 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/jsbn": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
-        },
         "node_modules/json-buffer": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -2877,17 +2801,6 @@
             },
             "bin": {
                 "json5": "lib/cli.js"
-            }
-        },
-        "node_modules/jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-            "dependencies": {
-                "universalify": "^2.0.0"
-            },
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
             }
         },
         "node_modules/just-extend": {
@@ -3281,6 +3194,15 @@
                 }
             }
         },
+        "node_modules/mri": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+            "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -3303,14 +3225,6 @@
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
-        },
-        "node_modules/netmask": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-            "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
-            "engines": {
-                "node": ">= 0.4.0"
-            }
         },
         "node_modules/nise": {
             "version": "5.1.4",
@@ -3438,9 +3352,9 @@
             }
         },
         "node_modules/optionator": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+            "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "dev": true,
             "dependencies": {
                 "deep-is": "^0.1.3",
@@ -3448,7 +3362,7 @@
                 "levn": "^0.4.1",
                 "prelude-ls": "^1.2.1",
                 "type-check": "^0.4.0",
-                "word-wrap": "^1.2.3"
+                "word-wrap": "^1.2.5"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -3490,36 +3404,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/pac-proxy-agent": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.1.tgz",
-            "integrity": "sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==",
-            "dependencies": {
-                "@tootallnate/quickjs-emscripten": "^0.23.0",
-                "agent-base": "^7.0.2",
-                "debug": "^4.3.4",
-                "get-uri": "^6.0.1",
-                "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.2",
-                "pac-resolver": "^7.0.0",
-                "socks-proxy-agent": "^8.0.2"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/pac-resolver": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
-            "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
-            "dependencies": {
-                "degenerator": "^5.0.0",
-                "netmask": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 14"
             }
         },
         "node_modules/parent-module": {
@@ -3601,36 +3485,19 @@
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
-        "node_modules/proxy-agent": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
-            "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+        "node_modules/proxy": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/proxy/-/proxy-2.1.1.tgz",
+            "integrity": "sha512-nLgd7zdUAOpB3ZO/xCkU8gy74UER7P0aihU8DkUsDS5ZoFwVCX7u8dy+cv5tVK8UaB/yminU1GiLWE26TKPYpg==",
+            "dev": true,
             "dependencies": {
-                "agent-base": "^7.0.2",
-                "debug": "^4.3.4",
-                "http-proxy-agent": "^7.0.1",
-                "https-proxy-agent": "^7.0.3",
-                "lru-cache": "^7.14.1",
-                "pac-proxy-agent": "^7.0.1",
-                "proxy-from-env": "^1.1.0",
-                "socks-proxy-agent": "^8.0.2"
+                "args": "^5.0.3",
+                "basic-auth-parser": "0.0.2-1",
+                "debug": "^4.3.4"
             },
             "engines": {
                 "node": ">= 14"
             }
-        },
-        "node_modules/proxy-agent/node_modules/lru-cache": {
-            "version": "7.18.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "node_modules/proxy-protocol-js": {
             "version": "4.0.6",
@@ -3648,9 +3515,9 @@
             }
         },
         "node_modules/punycode": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-            "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
             "engines": {
                 "node": ">=6"
@@ -3838,6 +3705,15 @@
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/rewire": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/rewire/-/rewire-7.0.0.tgz",
+            "integrity": "sha512-DyyNyzwMtGYgu0Zl/ya0PR/oaunM+VuCuBxCuhYJHHaV0V+YvYa3bBGxb5OZ71vndgmp1pYY8F4YOwQo1siRGw==",
+            "dev": true,
+            "dependencies": {
+                "eslint": "^8.47.0"
             }
         },
         "node_modules/rfdc": {
@@ -4047,50 +3923,6 @@
                 "url": "https://opencollective.com/sinon"
             }
         },
-        "node_modules/smart-buffer": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-            "engines": {
-                "node": ">= 6.0.0",
-                "npm": ">= 3.0.0"
-            }
-        },
-        "node_modules/socks": {
-            "version": "2.8.3",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-            "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
-            "dependencies": {
-                "ip-address": "^9.0.5",
-                "smart-buffer": "^4.2.0"
-            },
-            "engines": {
-                "node": ">= 10.0.0",
-                "npm": ">= 3.0.0"
-            }
-        },
-        "node_modules/socks-proxy-agent": {
-            "version": "8.0.3",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.3.tgz",
-            "integrity": "sha512-VNegTZKhuGq5vSD6XNKlbqWhyt/40CgoEw8XxD6dhnm8Jq9IEa3nIa4HwnM8XOqU0CdB0BwWVXusqiFXfHB3+A==",
-            "dependencies": {
-                "agent-base": "^7.1.1",
-                "debug": "^4.3.4",
-                "socks": "^2.7.1"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "optional": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/split2": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
@@ -4098,11 +3930,6 @@
             "dependencies": {
                 "readable-stream": "^3.0.0"
             }
-        },
-        "node_modules/sprintf-js": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
         },
         "node_modules/stream-shift": {
             "version": "1.0.1",
@@ -4297,11 +4124,6 @@
                 "strip-bom": "^3.0.0"
             }
         },
-        "node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4377,14 +4199,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/universalify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-            "engines": {
-                "node": ">= 10.0.0"
             }
         },
         "node_modules/uri-js": {
@@ -4675,20 +4489,20 @@
             }
         },
         "@eslint-community/regexpp": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
-            "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.1.tgz",
+            "integrity": "sha512-Zm2NGpWELsQAD1xsJzGQpYfvICSsFkEpU0jxBjfdC6uNEWXcHnfs9hScFWtXVDVl+rBQJGrl4g1vcKIejpH9dA==",
             "dev": true
         },
         "@eslint/eslintrc": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
-            "integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+            "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.5.2",
+                "espree": "^9.6.0",
                 "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
@@ -4698,9 +4512,9 @@
             }
         },
         "@eslint/js": {
-            "version": "8.43.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.43.0.tgz",
-            "integrity": "sha512-s2UHCoiXfxMvmfzqoN+vrQ84ahUSYde9qNO1MdxmoEhyHWsfmwOpFlwYV+ePJEVc7gFnATGUi376WowX1N7tFg==",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+            "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
             "dev": true
         },
         "@flowfuse/nr-theme": {
@@ -4709,13 +4523,13 @@
             "integrity": "sha512-Aqui1YNKmhwKnm+s/BlCCCrZVZk2BeTmBpNs8NdKFr0Jhnse6f9vBAGYppeoKHo3R+1ba9/YQCNhyB1vcS3f0A=="
         },
         "@humanwhocodes/config-array": {
-            "version": "0.11.10",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-            "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+            "version": "0.11.14",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+            "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
             "dev": true,
             "requires": {
-                "@humanwhocodes/object-schema": "^1.2.1",
-                "debug": "^4.1.1",
+                "@humanwhocodes/object-schema": "^2.0.2",
+                "debug": "^4.3.1",
                 "minimatch": "^3.0.5"
             }
         },
@@ -4726,9 +4540,9 @@
             "dev": true
         },
         "@humanwhocodes/object-schema": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-            "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+            "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
             "dev": true
         },
         "@nodelib/fs.scandir": {
@@ -4808,11 +4622,6 @@
                 "defer-to-connect": "^2.0.0"
             }
         },
-        "@tootallnate/quickjs-emscripten": {
-            "version": "0.23.0",
-            "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-            "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
-        },
         "@types/cacheable-request": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
@@ -4857,10 +4666,16 @@
                 "@types/node": "*"
             }
         },
+        "@ungap/structured-clone": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+            "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+            "dev": true
+        },
         "acorn": {
-            "version": "8.9.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
-            "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
+            "version": "8.11.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
             "dev": true
         },
         "acorn-jsx": {
@@ -5028,6 +4843,26 @@
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true
         },
+        "args": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/args/-/args-5.0.3.tgz",
+            "integrity": "sha512-h6k/zfFgusnv3i5TU08KQkVKuCPBtL/PWQbWkHUxvJrZ2nAyeaUupneemcrgn1xmqxPQsPIzwkUhOpoqPDRZuA==",
+            "dev": true,
+            "requires": {
+                "camelcase": "5.0.0",
+                "chalk": "2.4.2",
+                "leven": "2.1.0",
+                "mri": "1.1.4"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+                    "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+                    "dev": true
+                }
+            }
+        },
         "array-back": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
@@ -5084,14 +4919,6 @@
                 "es-shim-unscopables": "^1.0.0"
             }
         },
-        "ast-types": {
-            "version": "0.13.4",
-            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-            "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-            "requires": {
-                "tslib": "^2.0.1"
-            }
-        },
         "available-typed-arrays": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -5109,10 +4936,11 @@
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
-        "basic-ftp": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-            "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg=="
+        "basic-auth-parser": {
+            "version": "0.0.2-1",
+            "resolved": "https://registry.npmjs.org/basic-auth-parser/-/basic-auth-parser-0.0.2-1.tgz",
+            "integrity": "sha512-GFj8iVxo9onSU6BnnQvVwqvxh60UcSHJEDnIk3z4B6iOjsKSmqe+ibW0Rsz7YO7IE1HG3D3tqCNIidP46SZVdQ==",
+            "dev": true
         },
         "binary-extensions": {
             "version": "2.2.0",
@@ -5376,11 +5204,6 @@
                 "which": "^2.0.1"
             }
         },
-        "data-uri-to-buffer": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-            "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="
-        },
         "debug": {
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -5435,16 +5258,6 @@
             "requires": {
                 "has-property-descriptors": "^1.0.0",
                 "object-keys": "^1.1.1"
-            }
-        },
-        "degenerator": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
-            "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-            "requires": {
-                "ast-types": "^0.13.4",
-                "escodegen": "^2.1.0",
-                "esprima": "^4.0.1"
             }
         },
         "diff": {
@@ -5618,39 +5431,29 @@
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
         },
-        "escodegen": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-            "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-            "requires": {
-                "esprima": "^4.0.1",
-                "estraverse": "^5.2.0",
-                "esutils": "^2.0.2",
-                "source-map": "~0.6.1"
-            }
-        },
         "eslint": {
-            "version": "8.43.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.43.0.tgz",
-            "integrity": "sha512-aaCpf2JqqKesMFGgmRPessmVKjcGXqdlAYLLC3THM8t5nBRZRQ+st5WM/hoJXkdioEXLLbXgclUpM0TXo5HX5Q==",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+            "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
             "dev": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.2.0",
-                "@eslint-community/regexpp": "^4.4.0",
-                "@eslint/eslintrc": "^2.0.3",
-                "@eslint/js": "8.43.0",
-                "@humanwhocodes/config-array": "^0.11.10",
+                "@eslint-community/regexpp": "^4.6.1",
+                "@eslint/eslintrc": "^2.1.4",
+                "@eslint/js": "8.57.0",
+                "@humanwhocodes/config-array": "^0.11.14",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
-                "ajv": "^6.10.0",
+                "@ungap/structured-clone": "^1.2.0",
+                "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
                 "debug": "^4.3.2",
                 "doctrine": "^3.0.0",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^7.2.0",
-                "eslint-visitor-keys": "^3.4.1",
-                "espree": "^9.5.2",
+                "eslint-scope": "^7.2.2",
+                "eslint-visitor-keys": "^3.4.3",
+                "espree": "^9.6.1",
                 "esquery": "^1.4.2",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
@@ -5660,7 +5463,6 @@
                 "globals": "^13.19.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.2.0",
-                "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
                 "is-path-inside": "^3.0.3",
@@ -5670,9 +5472,8 @@
                 "lodash.merge": "^4.6.2",
                 "minimatch": "^3.1.2",
                 "natural-compare": "^1.4.0",
-                "optionator": "^0.9.1",
+                "optionator": "^0.9.3",
                 "strip-ansi": "^6.0.1",
-                "strip-json-comments": "^3.1.0",
                 "text-table": "^0.2.0"
             },
             "dependencies": {
@@ -5871,6 +5672,12 @@
                 "semver": "^7.5.0"
             }
         },
+        "eslint-plugin-no-only-tests": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.1.0.tgz",
+            "integrity": "sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==",
+            "dev": true
+        },
         "eslint-plugin-node": {
             "version": "11.1.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
@@ -5902,9 +5709,9 @@
             "requires": {}
         },
         "eslint-scope": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
-            "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+            "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
             "dev": true,
             "requires": {
                 "esrecurse": "^4.3.0",
@@ -5929,26 +5736,21 @@
             }
         },
         "eslint-visitor-keys": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-            "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "dev": true
         },
         "espree": {
-            "version": "9.5.2",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
-            "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
             "dev": true,
             "requires": {
-                "acorn": "^8.8.0",
+                "acorn": "^8.9.0",
                 "acorn-jsx": "^5.3.2",
                 "eslint-visitor-keys": "^3.4.1"
             }
-        },
-        "esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         },
         "esquery": {
             "version": "1.5.0",
@@ -5971,12 +5773,14 @@
         "estraverse": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true
         },
         "esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+            "dev": true
         },
         "fast-deep-equal": {
             "version": "3.1.3",
@@ -6104,16 +5908,6 @@
             "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
             "dev": true
         },
-        "fs-extra": {
-            "version": "11.2.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-            "requires": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            }
-        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -6190,17 +5984,6 @@
                 "get-intrinsic": "^1.1.1"
             }
         },
-        "get-uri": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
-            "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
-            "requires": {
-                "basic-ftp": "^5.0.2",
-                "data-uri-to-buffer": "^6.0.2",
-                "debug": "^4.3.4",
-                "fs-extra": "^11.2.0"
-            }
-        },
         "glob": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -6224,9 +6007,9 @@
             }
         },
         "globals": {
-            "version": "13.20.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-            "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+            "version": "13.24.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
             "dev": true,
             "requires": {
                 "type-fest": "^0.20.2"
@@ -6269,11 +6052,6 @@
                 "p-cancelable": "^2.0.0",
                 "responselike": "^2.0.0"
             }
-        },
-        "graceful-fs": {
-            "version": "4.2.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
         },
         "graphemer": {
             "version": "1.4.0",
@@ -6465,15 +6243,6 @@
                 "get-intrinsic": "^1.2.0",
                 "has": "^1.0.3",
                 "side-channel": "^1.0.4"
-            }
-        },
-        "ip-address": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-            "requires": {
-                "jsbn": "1.1.0",
-                "sprintf-js": "^1.1.3"
             }
         },
         "is-array-buffer": {
@@ -6697,11 +6466,6 @@
                 "argparse": "^2.0.1"
             }
         },
-        "jsbn": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
-        },
         "json-buffer": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -6727,15 +6491,6 @@
             "peer": true,
             "requires": {
                 "minimist": "^1.2.0"
-            }
-        },
-        "jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-            "requires": {
-                "graceful-fs": "^4.1.6",
-                "universalify": "^2.0.0"
             }
         },
         "just-extend": {
@@ -7022,6 +6777,12 @@
                 "process-nextick-args": "^2.0.1"
             }
         },
+        "mri": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+            "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
+            "dev": true
+        },
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -7038,11 +6799,6 @@
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
-        },
-        "netmask": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-            "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
         },
         "nise": {
             "version": "5.1.4",
@@ -7147,9 +6903,9 @@
             }
         },
         "optionator": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+            "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "dev": true,
             "requires": {
                 "deep-is": "^0.1.3",
@@ -7157,7 +6913,7 @@
                 "levn": "^0.4.1",
                 "prelude-ls": "^1.2.1",
                 "type-check": "^0.4.0",
-                "word-wrap": "^1.2.3"
+                "word-wrap": "^1.2.5"
             }
         },
         "p-cancelable": {
@@ -7181,30 +6937,6 @@
             "dev": true,
             "requires": {
                 "p-limit": "^3.0.2"
-            }
-        },
-        "pac-proxy-agent": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.1.tgz",
-            "integrity": "sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==",
-            "requires": {
-                "@tootallnate/quickjs-emscripten": "^0.23.0",
-                "agent-base": "^7.0.2",
-                "debug": "^4.3.4",
-                "get-uri": "^6.0.1",
-                "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.2",
-                "pac-resolver": "^7.0.0",
-                "socks-proxy-agent": "^8.0.2"
-            }
-        },
-        "pac-resolver": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
-            "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
-            "requires": {
-                "degenerator": "^5.0.0",
-                "netmask": "^2.0.2"
             }
         },
         "parent-module": {
@@ -7265,32 +6997,16 @@
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
-        "proxy-agent": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
-            "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+        "proxy": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/proxy/-/proxy-2.1.1.tgz",
+            "integrity": "sha512-nLgd7zdUAOpB3ZO/xCkU8gy74UER7P0aihU8DkUsDS5ZoFwVCX7u8dy+cv5tVK8UaB/yminU1GiLWE26TKPYpg==",
+            "dev": true,
             "requires": {
-                "agent-base": "^7.0.2",
-                "debug": "^4.3.4",
-                "http-proxy-agent": "^7.0.1",
-                "https-proxy-agent": "^7.0.3",
-                "lru-cache": "^7.14.1",
-                "pac-proxy-agent": "^7.0.1",
-                "proxy-from-env": "^1.1.0",
-                "socks-proxy-agent": "^8.0.2"
-            },
-            "dependencies": {
-                "lru-cache": {
-                    "version": "7.18.3",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-                    "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
-                }
+                "args": "^5.0.3",
+                "basic-auth-parser": "0.0.2-1",
+                "debug": "^4.3.4"
             }
-        },
-        "proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "proxy-protocol-js": {
             "version": "4.0.6",
@@ -7308,9 +7024,9 @@
             }
         },
         "punycode": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-            "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true
         },
         "qlobber": {
@@ -7433,6 +7149,15 @@
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
             "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
             "dev": true
+        },
+        "rewire": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/rewire/-/rewire-7.0.0.tgz",
+            "integrity": "sha512-DyyNyzwMtGYgu0Zl/ya0PR/oaunM+VuCuBxCuhYJHHaV0V+YvYa3bBGxb5OZ71vndgmp1pYY8F4YOwQo1siRGw==",
+            "dev": true,
+            "requires": {
+                "eslint": "^8.47.0"
+            }
         },
         "rfdc": {
             "version": "1.3.0",
@@ -7584,36 +7309,6 @@
                 "supports-color": "^7.2.0"
             }
         },
-        "smart-buffer": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
-        },
-        "socks": {
-            "version": "2.8.3",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-            "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
-            "requires": {
-                "ip-address": "^9.0.5",
-                "smart-buffer": "^4.2.0"
-            }
-        },
-        "socks-proxy-agent": {
-            "version": "8.0.3",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.3.tgz",
-            "integrity": "sha512-VNegTZKhuGq5vSD6XNKlbqWhyt/40CgoEw8XxD6dhnm8Jq9IEa3nIa4HwnM8XOqU0CdB0BwWVXusqiFXfHB3+A==",
-            "requires": {
-                "agent-base": "^7.1.1",
-                "debug": "^4.3.4",
-                "socks": "^2.7.1"
-            }
-        },
-        "source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "optional": true
-        },
         "split2": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
@@ -7621,11 +7316,6 @@
             "requires": {
                 "readable-stream": "^3.0.0"
             }
-        },
-        "sprintf-js": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
         },
         "stream-shift": {
             "version": "1.0.1",
@@ -7773,11 +7463,6 @@
                 "strip-bom": "^3.0.0"
             }
         },
-        "tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -7833,11 +7518,6 @@
                 "has-symbols": "^1.0.3",
                 "which-boxed-primitive": "^1.0.2"
             }
-        },
-        "universalify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
         },
         "uri-js": {
             "version": "4.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "command-line-usage": "^6.1.3",
                 "got": "^11.8.6",
                 "mqtt": "^4.3.7",
+                "proxy-agent": "^6.4.0",
                 "semver": "^7.3.8",
                 "ws": "^8.13.0",
                 "yaml": "^2.1.1"
@@ -231,6 +232,11 @@
                 "node": ">=10"
             }
         },
+        "node_modules/@tootallnate/quickjs-emscripten": {
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+            "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
+        },
         "node_modules/@types/cacheable-request": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
@@ -437,6 +443,17 @@
                 }
             }
         },
+        "node_modules/agent-base": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+            "dependencies": {
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/ajv": {
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -581,6 +598,17 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/ast-types": {
+            "version": "0.13.4",
+            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+            "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+            "dependencies": {
+                "tslib": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/available-typed-arrays": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -617,6 +645,14 @@
                     "url": "https://feross.org/support"
                 }
             ]
+        },
+        "node_modules/basic-ftp": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+            "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+            "engines": {
+                "node": ">=10.0.0"
+            }
         },
         "node_modules/binary-extensions": {
             "version": "2.2.0",
@@ -956,6 +992,14 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/data-uri-to-buffer": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+            "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/debug": {
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -1046,6 +1090,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/degenerator": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+            "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+            "dependencies": {
+                "ast-types": "^0.13.4",
+                "escodegen": "^2.1.0",
+                "esprima": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/diff": {
@@ -1268,6 +1325,26 @@
             "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
             "engines": {
                 "node": ">=0.8.0"
+            }
+        },
+        "node_modules/escodegen": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+            "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+            "dependencies": {
+                "esprima": "^4.0.1",
+                "estraverse": "^5.2.0",
+                "esutils": "^2.0.2"
+            },
+            "bin": {
+                "escodegen": "bin/escodegen.js",
+                "esgenerate": "bin/esgenerate.js"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "optionalDependencies": {
+                "source-map": "~0.6.1"
             }
         },
         "node_modules/eslint": {
@@ -1714,6 +1791,18 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
+        "node_modules/esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "bin": {
+                "esparse": "bin/esparse.js",
+                "esvalidate": "bin/esvalidate.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/esquery": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
@@ -1742,7 +1831,6 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "dev": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -1751,7 +1839,6 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -1909,6 +1996,19 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/fs-extra": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.14"
+            }
+        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2019,6 +2119,20 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/get-uri": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
+            "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
+            "dependencies": {
+                "basic-ftp": "^5.0.2",
+                "data-uri-to-buffer": "^6.0.2",
+                "debug": "^4.3.4",
+                "fs-extra": "^11.2.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/glob": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -2117,6 +2231,11 @@
             "funding": {
                 "url": "https://github.com/sindresorhus/got?sponsor=1"
             }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
         },
         "node_modules/graphemer": {
             "version": "1.4.0",
@@ -2252,6 +2371,18 @@
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
             "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
         },
+        "node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/http2-wrapper": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
@@ -2262,6 +2393,18 @@
             },
             "engines": {
                 "node": ">=10.19.0"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+            "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+            "dependencies": {
+                "agent-base": "^7.0.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/hyperid": {
@@ -2363,6 +2506,18 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/ip-address": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+            "dependencies": {
+                "jsbn": "1.1.0",
+                "sprintf-js": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 12"
             }
         },
         "node_modules/is-array-buffer": {
@@ -2689,6 +2844,11 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/jsbn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+        },
         "node_modules/json-buffer": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -2717,6 +2877,17 @@
             },
             "bin": {
                 "json5": "lib/cli.js"
+            }
+        },
+        "node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
             }
         },
         "node_modules/just-extend": {
@@ -3133,6 +3304,14 @@
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
         },
+        "node_modules/netmask": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+            "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
         "node_modules/nise": {
             "version": "5.1.4",
             "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
@@ -3313,6 +3492,36 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/pac-proxy-agent": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.1.tgz",
+            "integrity": "sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==",
+            "dependencies": {
+                "@tootallnate/quickjs-emscripten": "^0.23.0",
+                "agent-base": "^7.0.2",
+                "debug": "^4.3.4",
+                "get-uri": "^6.0.1",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.2",
+                "pac-resolver": "^7.0.0",
+                "socks-proxy-agent": "^8.0.2"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/pac-resolver": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+            "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+            "dependencies": {
+                "degenerator": "^5.0.0",
+                "netmask": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3391,6 +3600,37 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+        },
+        "node_modules/proxy-agent": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
+            "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+            "dependencies": {
+                "agent-base": "^7.0.2",
+                "debug": "^4.3.4",
+                "http-proxy-agent": "^7.0.1",
+                "https-proxy-agent": "^7.0.3",
+                "lru-cache": "^7.14.1",
+                "pac-proxy-agent": "^7.0.1",
+                "proxy-from-env": "^1.1.0",
+                "socks-proxy-agent": "^8.0.2"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/proxy-agent/node_modules/lru-cache": {
+            "version": "7.18.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "node_modules/proxy-protocol-js": {
             "version": "4.0.6",
@@ -3807,6 +4047,50 @@
                 "url": "https://opencollective.com/sinon"
             }
         },
+        "node_modules/smart-buffer": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+            "engines": {
+                "node": ">= 6.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/socks": {
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+            "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+            "dependencies": {
+                "ip-address": "^9.0.5",
+                "smart-buffer": "^4.2.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/socks-proxy-agent": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.3.tgz",
+            "integrity": "sha512-VNegTZKhuGq5vSD6XNKlbqWhyt/40CgoEw8XxD6dhnm8Jq9IEa3nIa4HwnM8XOqU0CdB0BwWVXusqiFXfHB3+A==",
+            "dependencies": {
+                "agent-base": "^7.1.1",
+                "debug": "^4.3.4",
+                "socks": "^2.7.1"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "optional": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/split2": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
@@ -3814,6 +4098,11 @@
             "dependencies": {
                 "readable-stream": "^3.0.0"
             }
+        },
+        "node_modules/sprintf-js": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
         },
         "node_modules/stream-shift": {
             "version": "1.0.1",
@@ -4008,6 +4297,11 @@
                 "strip-bom": "^3.0.0"
             }
         },
+        "node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
         "node_modules/type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4083,6 +4377,14 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "engines": {
+                "node": ">= 10.0.0"
             }
         },
         "node_modules/uri-js": {
@@ -4506,6 +4808,11 @@
                 "defer-to-connect": "^2.0.0"
             }
         },
+        "@tootallnate/quickjs-emscripten": {
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+            "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
+        },
         "@types/cacheable-request": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
@@ -4665,6 +4972,14 @@
                 }
             }
         },
+        "agent-base": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+            "requires": {
+                "debug": "^4.3.4"
+            }
+        },
         "ajv": {
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -4769,6 +5084,14 @@
                 "es-shim-unscopables": "^1.0.0"
             }
         },
+        "ast-types": {
+            "version": "0.13.4",
+            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+            "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+            "requires": {
+                "tslib": "^2.0.1"
+            }
+        },
         "available-typed-arrays": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -4785,6 +5108,11 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        },
+        "basic-ftp": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+            "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg=="
         },
         "binary-extensions": {
             "version": "2.2.0",
@@ -5048,6 +5376,11 @@
                 "which": "^2.0.1"
             }
         },
+        "data-uri-to-buffer": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+            "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="
+        },
         "debug": {
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -5102,6 +5435,16 @@
             "requires": {
                 "has-property-descriptors": "^1.0.0",
                 "object-keys": "^1.1.1"
+            }
+        },
+        "degenerator": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+            "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+            "requires": {
+                "ast-types": "^0.13.4",
+                "escodegen": "^2.1.0",
+                "esprima": "^4.0.1"
             }
         },
         "diff": {
@@ -5274,6 +5617,17 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+        },
+        "escodegen": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+            "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+            "requires": {
+                "esprima": "^4.0.1",
+                "estraverse": "^5.2.0",
+                "esutils": "^2.0.2",
+                "source-map": "~0.6.1"
+            }
         },
         "eslint": {
             "version": "8.43.0",
@@ -5591,6 +5945,11 @@
                 "eslint-visitor-keys": "^3.4.1"
             }
         },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+        },
         "esquery": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
@@ -5612,14 +5971,12 @@
         "estraverse": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "dev": true
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
         },
         "esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-            "dev": true
+            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
         },
         "fast-deep-equal": {
             "version": "3.1.3",
@@ -5747,6 +6104,16 @@
             "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
             "dev": true
         },
+        "fs-extra": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+            "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            }
+        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5823,6 +6190,17 @@
                 "get-intrinsic": "^1.1.1"
             }
         },
+        "get-uri": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
+            "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
+            "requires": {
+                "basic-ftp": "^5.0.2",
+                "data-uri-to-buffer": "^6.0.2",
+                "debug": "^4.3.4",
+                "fs-extra": "^11.2.0"
+            }
+        },
         "glob": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -5891,6 +6269,11 @@
                 "p-cancelable": "^2.0.0",
                 "responselike": "^2.0.0"
             }
+        },
+        "graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
         },
         "graphemer": {
             "version": "1.4.0",
@@ -5986,6 +6369,15 @@
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
             "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
         },
+        "http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "requires": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            }
+        },
         "http2-wrapper": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
@@ -5993,6 +6385,15 @@
             "requires": {
                 "quick-lru": "^5.1.1",
                 "resolve-alpn": "^1.0.0"
+            }
+        },
+        "https-proxy-agent": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+            "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+            "requires": {
+                "agent-base": "^7.0.2",
+                "debug": "4"
             }
         },
         "hyperid": {
@@ -6064,6 +6465,15 @@
                 "get-intrinsic": "^1.2.0",
                 "has": "^1.0.3",
                 "side-channel": "^1.0.4"
+            }
+        },
+        "ip-address": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+            "requires": {
+                "jsbn": "1.1.0",
+                "sprintf-js": "^1.1.3"
             }
         },
         "is-array-buffer": {
@@ -6287,6 +6697,11 @@
                 "argparse": "^2.0.1"
             }
         },
+        "jsbn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+        },
         "json-buffer": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -6312,6 +6727,15 @@
             "peer": true,
             "requires": {
                 "minimist": "^1.2.0"
+            }
+        },
+        "jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "requires": {
+                "graceful-fs": "^4.1.6",
+                "universalify": "^2.0.0"
             }
         },
         "just-extend": {
@@ -6615,6 +7039,11 @@
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
         },
+        "netmask": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+            "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
+        },
         "nise": {
             "version": "5.1.4",
             "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
@@ -6754,6 +7183,30 @@
                 "p-limit": "^3.0.2"
             }
         },
+        "pac-proxy-agent": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.1.tgz",
+            "integrity": "sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==",
+            "requires": {
+                "@tootallnate/quickjs-emscripten": "^0.23.0",
+                "agent-base": "^7.0.2",
+                "debug": "^4.3.4",
+                "get-uri": "^6.0.1",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.2",
+                "pac-resolver": "^7.0.0",
+                "socks-proxy-agent": "^8.0.2"
+            }
+        },
+        "pac-resolver": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+            "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+            "requires": {
+                "degenerator": "^5.0.0",
+                "netmask": "^2.0.2"
+            }
+        },
         "parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6811,6 +7264,33 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+        },
+        "proxy-agent": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
+            "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+            "requires": {
+                "agent-base": "^7.0.2",
+                "debug": "^4.3.4",
+                "http-proxy-agent": "^7.0.1",
+                "https-proxy-agent": "^7.0.3",
+                "lru-cache": "^7.14.1",
+                "pac-proxy-agent": "^7.0.1",
+                "proxy-from-env": "^1.1.0",
+                "socks-proxy-agent": "^8.0.2"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "7.18.3",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+                    "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
+                }
+            }
+        },
+        "proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "proxy-protocol-js": {
             "version": "4.0.6",
@@ -7104,6 +7584,36 @@
                 "supports-color": "^7.2.0"
             }
         },
+        "smart-buffer": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+        },
+        "socks": {
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+            "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+            "requires": {
+                "ip-address": "^9.0.5",
+                "smart-buffer": "^4.2.0"
+            }
+        },
+        "socks-proxy-agent": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.3.tgz",
+            "integrity": "sha512-VNegTZKhuGq5vSD6XNKlbqWhyt/40CgoEw8XxD6dhnm8Jq9IEa3nIa4HwnM8XOqU0CdB0BwWVXusqiFXfHB3+A==",
+            "requires": {
+                "agent-base": "^7.1.1",
+                "debug": "^4.3.4",
+                "socks": "^2.7.1"
+            }
+        },
+        "source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "optional": true
+        },
         "split2": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
@@ -7111,6 +7621,11 @@
             "requires": {
                 "readable-stream": "^3.0.0"
             }
+        },
+        "sprintf-js": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
         },
         "stream-shift": {
             "version": "1.0.1",
@@ -7258,6 +7773,11 @@
                 "strip-bom": "^3.0.0"
             }
         },
+        "tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
         "type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -7313,6 +7833,11 @@
                 "has-symbols": "^1.0.3",
                 "which-boxed-primitive": "^1.0.2"
             }
+        },
+        "universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
         },
         "uri-js": {
             "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -38,8 +38,9 @@
         "command-line-args": "^5.2.1",
         "command-line-usage": "^6.1.3",
         "got": "^11.8.6",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.4",
         "mqtt": "^4.3.7",
-        "proxy-agent": "^6.4.0",
         "semver": "^7.3.8",
         "ws": "^8.13.0",
         "yaml": "^2.1.1"
@@ -50,8 +51,11 @@
         "eslint": "^8.25.0",
         "eslint-config-standard": "^17.0.0",
         "eslint-plugin-html": "^7.1.0",
+        "eslint-plugin-no-only-tests": "^3.1.0",
         "eslint-plugin-node": "^11.1.0",
         "mocha": "^10.0.0",
+        "proxy": "^2.1.1",
+        "rewire": "^7.0.0",
         "should": "^13.2.3",
         "sinon": "^14.0.0"
     },

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.4",
         "mqtt": "^4.3.7",
+        "proxy-from-env": "^1.1.0",
         "semver": "^7.3.8",
         "ws": "^8.13.0",
         "yaml": "^2.1.1"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "command-line-usage": "^6.1.3",
         "got": "^11.8.6",
         "mqtt": "^4.3.7",
+        "proxy-agent": "^6.4.0",
         "semver": "^7.3.8",
         "ws": "^8.13.0",
         "yaml": "^2.1.1"

--- a/test/unit/lib/AgentManager_spec.js
+++ b/test/unit/lib/AgentManager_spec.js
@@ -200,6 +200,7 @@ describe('Test the AgentManager', function () {
             delete process.env.http_proxy
             delete process.env.https_proxy
             delete process.env.no_proxy
+            delete process.env.all_proxy
         })
 
         it('Calls GOT with no agent when env vars are not set', async function () {

--- a/test/unit/lib/auditLogger/index_spec.js
+++ b/test/unit/lib/auditLogger/index_spec.js
@@ -5,7 +5,7 @@ const { HttpProxyAgent } = require('http-proxy-agent')
 const { HttpsProxyAgent } = require('https-proxy-agent')
 const rewire = require('rewire')
 
-describe.only('auditLogger', () => {
+describe('auditLogger', () => {
     function setup (settings) {
         const module = rewire('../../../../lib/auditLogger/index.js')
         const logger = module(settings)

--- a/test/unit/lib/auditLogger/index_spec.js
+++ b/test/unit/lib/auditLogger/index_spec.js
@@ -1,0 +1,236 @@
+const mocha = require('mocha') // eslint-disable-line
+const sinon = require('sinon')
+const should = require('should')
+const { HttpProxyAgent } = require('http-proxy-agent')
+const { HttpsProxyAgent } = require('https-proxy-agent')
+const rewire = require('rewire')
+
+describe('auditLogger', () => {
+    function setup (settings) {
+        const module = rewire('../../../../lib/auditLogger/index.js')
+        const logger = module(settings)
+        sinon.stub(module.__get__('got'), 'post').resolves()
+        return { module, logger }
+    }
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    it('should send log message to the logging URL', () => {
+        const settings = {
+            loggingURL: 'https://example.com/logs',
+            token: 'my-token'
+        }
+        const logMessage = {
+            event: 'test-event',
+            user: {
+                userId: 'test-user-id'
+            },
+
+            message: 'Test log message'
+        }
+
+        const { module, logger } = setup(settings)
+        logger(logMessage)
+
+        const got = module.__get__('got')
+        got.post.calledOnce.should.be.true()
+        got.post.calledWith('https://example.com/logs', {
+            json: logMessage,
+            responseType: 'json',
+            headers: {
+                'user-agent': 'FlowFuse Device Agent Audit Logging v0.1',
+                authorization: 'Bearer my-token'
+            }
+        }).should.be.true()
+    })
+
+    it('should ignore comms events and any .get events', () => {
+        const settings = {
+            loggingURL: 'https://example.com/logs',
+            token: 'my-token'
+        }
+        const logMessage1 = {
+            event: 'comms.event',
+            user: {
+                userId: 'test-user-id'
+            },
+
+            message: 'Test log message'
+        }
+        const logMessage2 = {
+            event: 'data.get',
+            user: {
+                userId: 'test-user-id'
+            },
+
+            message: 'Test log message'
+        }
+        const { module, logger } = setup(settings)
+        const got = module.__get__('got')
+
+        logger(logMessage1)
+        logger(logMessage2)
+
+        got.post.called.should.be.false()
+    })
+
+    it('should ignore auth events except auth.log events', () => {
+        const settings = {
+            loggingURL: 'https://example.com/logs',
+            token: 'my-token'
+        }
+        const logMessage1 = {
+            event: 'auth.event',
+            user: {
+                userId: 'test-user-id'
+            },
+
+            message: 'Test log message'
+        }
+        const logMessage2 = {
+            event: 'auth.log.event',
+            user: {
+                userId: 'test-user-id'
+            },
+
+            message: 'Test log message'
+        }
+        const { module, logger } = setup(settings)
+        logger(logMessage1)
+        logger(logMessage2)
+
+        const got = module.__get__('got')
+        got.post.calledOnce.should.be.true()
+        got.post.calledWith('https://example.com/logs', {
+            json: logMessage2,
+            responseType: 'json',
+            headers: {
+                'user-agent': 'FlowFuse Device Agent Audit Logging v0.1',
+                authorization: 'Bearer my-token'
+            }
+        }).should.be.true()
+    })
+
+    it('should remove username and level properties from the log message', () => {
+        const settings = {
+            loggingURL: 'https://example.com/logs',
+            token: 'my-token'
+        }
+        const logMessage = {
+            event: 'test-event',
+            user: {
+                userId: 'test-user-id'
+            },
+            username: 'test-username',
+            level: 'info',
+            message: 'Test log message'
+        }
+
+        const { module, logger } = setup(settings)
+        logger(logMessage)
+
+        const got = module.__get__('got')
+        got.post.calledOnce.should.be.true()
+        got.post.calledWith('https://example.com/logs', {
+            json: {
+                event: 'test-event',
+                user: 'test-user-id',
+                message: 'Test log message'
+            },
+            responseType: 'json',
+            headers: {
+                'user-agent': 'FlowFuse Device Agent Audit Logging v0.1',
+                authorization: 'Bearer my-token'
+            }
+        }).should.be.true()
+    })
+
+    it('should not have a proxy if env vars are not set', () => {
+        const settings = {
+            loggingURL: 'https://example.com/logs',
+            token: 'my-token'
+        }
+        const logMessage = {
+            event: 'test-event',
+            user: {
+                userId: 'test-user-id'
+            },
+            message: 'Test log message'
+        }
+        sinon.stub(process, 'env').value({
+            ...process.env,
+            http_proxy: '',
+            https_proxy: ''
+        })
+
+        const { module, logger } = setup(settings)
+        logger(logMessage)
+
+        const got = module.__get__('got')
+        got.post.calledOnce.should.be.true()
+        should.not.exist(got.defaults.options.agent?.http)
+        should.not.exist(got.defaults.options.agent?.https)
+    })
+
+    it('should use HTTP proxy agent if http_proxy environment variable is set', () => {
+        const settings = {
+            loggingURL: 'https://example.com/logs',
+            token: 'my-token'
+        }
+        sinon.stub(process, 'env').value({
+            ...process.env,
+            http_proxy: 'http://localhost:1234'
+        })
+        const { module, logger } = setup(settings)
+        logger({ event: 'test-event', message: 'Test log message' })
+
+        const got = module.__get__('got')
+        got.post.calledOnce.should.be.true()
+        should(got.defaults.options.agent.http).be.instanceOf(HttpProxyAgent)
+        got.defaults.options.agent.http.proxy.should.have.property('hostname', 'localhost')
+        got.defaults.options.agent.http.proxy.should.have.property('port', '1234')
+        should.not.exist(got.defaults.options.agent.https)
+    })
+
+    it('should use HTTPS proxy agent if https_proxy environment variable is set', () => {
+        const settings = {
+            loggingURL: 'https://example.com/logs',
+            token: 'my-token'
+        }
+        sinon.stub(process, 'env').value({
+            ...process.env,
+            https_proxy: 'http://localhost:4567'
+        })
+
+        const { module, logger } = setup(settings)
+        logger({ event: 'test-event', message: 'Test log message' })
+
+        const got = module.__get__('got')
+        got.post.calledOnce.should.be.true()
+        should(got.defaults.options.agent.https).be.instanceOf(HttpsProxyAgent)
+        got.defaults.options.agent.https.proxy.should.have.property('hostname', 'localhost')
+        got.defaults.options.agent.https.proxy.should.have.property('port', '4567')
+        should.not.exist(got.defaults.options.agent.http)
+    })
+
+    it('should use both HTTP & HTTPS proxy agent if env vars are set', () => {
+        const settings = {
+            loggingURL: 'https://example.com/logs',
+            token: 'my-token'
+        }
+        sinon.stub(process, 'env').value({
+            ...process.env,
+            http_proxy: 'http://http_proxy:8888',
+            https_proxy: 'http://http_proxy:8888'
+        })
+
+        const { module, logger } = setup(settings)
+        logger({ event: 'test-event', message: 'Test log message' })
+
+        const got = module.__get__('got')
+        got.post.calledOnce.should.be.true()
+        should(got.defaults.options.agent.https).be.instanceOf(HttpsProxyAgent)
+        should(got.defaults.options.agent.http).be.instanceOf(HttpProxyAgent)
+    })
+})

--- a/test/unit/lib/http_spec.js
+++ b/test/unit/lib/http_spec.js
@@ -108,7 +108,7 @@ describe('HTTP Comms', function () {
         sinon.stub(console, 'log') // hush console.log
         sinon.stub(console, 'info') // hush console.info
     })
-    
+
     afterEach(async function () {
         delete process.env.http_proxy
         delete process.env.https_proxy

--- a/test/unit/lib/http_spec.js
+++ b/test/unit/lib/http_spec.js
@@ -1,0 +1,202 @@
+const mocha = require('mocha') // eslint-disable-line
+const should = require('should') // eslint-disable-line
+const sinon = require('sinon')
+const { HTTPClient } = require('../../../lib/http')
+let currentId = 0 // incrementing id for each agent
+
+/** creates a mock Agent with sinon fakes for the methods
+ * getState, setState, getCurrentFlows, getCurrentCredentials, getCurrentPackage
+ * @param {object} opts
+ * @param {string} opts.currentMode
+ * @param {string} opts.currentSnapshot
+ * @param {string} opts.currentProject
+ * @param {string} opts.currentSettings
+ * @param {string} opts.state
+ * @param {object} opts.flows
+ * @param {string} opts.credentials
+ * @param {string} opts.package
+ * @returns {Agent}
+ */
+function createAgent (opts) {
+    opts = opts || {}
+    opts.state = opts.state || 'stopped'
+    const newAgent = function () {
+        this.updating = false
+        this.currentMode = opts.currentMode || null
+        this.editorToken = opts.editorToken
+        this.currentSnapshot = opts.currentSnapshot
+        this.currentProject = opts.currentProject
+        this.currentSettings = opts.currentSettings
+        this.state = opts.currentState
+        this.flows = opts.flows
+        this.credentials = opts.credentials
+        this.package = opts.package
+        const agent = this
+        return {
+            currentMode: agent.currentMode,
+            editorToken: agent.editorToken,
+            currentSnapshot: agent.currentSnapshot,
+            currentProject: agent.currentProject,
+            currentSettings: agent.currentSettings,
+            getState: sinon.fake.returns(agent.state),
+            setState: sinon.fake.call(function (state) {
+                agent.state = agent.state || {}
+                agent.state = Object.assign({}, agent.state, state)
+            }),
+            getCurrentFlows: sinon.fake.returns(agent.flows),
+            getCurrentCredentials: sinon.fake.returns(agent.credentials),
+            getCurrentPackage: sinon.fake.returns(agent.package),
+            saveEditorToken: sinon.fake(),
+            startNR: sinon.fake.returns(true),
+            restartNR: sinon.fake.returns(true),
+            suspendNR: sinon.fake.returns(true),
+            checkIn: sinon.fake()
+        }
+    }
+    return newAgent()
+}
+
+/**
+ * Create a new httpClientComms instance
+ * @param {*} opts - lib/mqtt options
+ * @param {string} opts.device - device id
+ * @param {string} opts.project - project id
+ * @param {string} opts.snapshotId - snapshot id
+ * @param {string} opts.settingsId - settings id
+ * @param {string} opts.mode - mode
+ * @param {string} opts.editorToken - editor token
+ * @param {string} opts.state - state
+ * @param {object} opts.flows - flows
+ * @param {string} opts.credentials - credentials
+ * @param {string} opts.package - package
+ */
+function createHttpClient (opts, clientOpts) {
+    opts = opts || {}
+    currentId++
+    const device = opts.device || `device${currentId}`
+    const project = opts.project !== null ? `project${currentId}` : null
+    const snapshot = opts.snapshotId !== null ? { id: opts.snapshotId } : null
+    const settings = opts.settingsId !== null ? { hash: opts.settingsId } : null
+    const mode = opts.mode || 'developer'
+    const editorToken = opts.editorToken || null
+
+    const agent = createAgent({
+        currentMode: mode,
+        editorToken,
+        currentProject: project,
+        currentSettings: settings,
+        currentSnapshot: snapshot,
+        state: opts.state || 'stopped',
+        flows: opts.flows,
+        credentials: opts.credentials,
+        package: opts.package
+    })
+
+    clientOpts = clientOpts || {}
+    const daHTTP = new HTTPClient(agent, {
+        forgeURL: clientOpts.forgeURL || 'http://localhost:9000',
+        deviceId: device,
+        token: clientOpts.token || 'token' + currentId
+    })
+
+    sinon.stub(daHTTP.heartbeat, 'start')
+    return daHTTP
+}
+
+describe('HTTP Comms', function () {
+    beforeEach(async function () {
+        sinon.stub(console, 'log') // hush console.log
+        sinon.stub(console, 'info') // hush console.info
+    })
+
+    afterEach(async function () {
+        sinon.restore()
+    })
+
+    it('Creates the HTTP Comms Client', async function () {
+        // ensure proxy settings are not set
+        sinon.stub(process, 'env').value({
+            ...process.env,
+            http_proxy: '',
+            https_proxy: '',
+            no_proxy: '',
+            all_proxy: ''
+        })
+        const httpClient = createHttpClient({
+            device: 'my-device-1',
+            project: 'project1',
+            snapshotId: 'snapshot1',
+            settingsId: 'settings1',
+            mode: 'developer',
+            editorToken: 'editor-token'
+        }, {
+            forgeURL: 'http://localhost:9876',
+            token: 'token-token-123'
+        })
+        httpClient.should.have.a.property('agent').and.be.an.Object()
+        httpClient.should.have.a.property('config').and.be.an.Object()
+        httpClient.config.should.have.a.property('forgeURL', 'http://localhost:9876')
+        httpClient.config.should.have.a.property('token', 'token-token-123')
+        httpClient.config.should.have.a.property('deviceId', 'my-device-1')
+
+        // ensure the client is a got instance
+        httpClient.should.have.property('client')
+        httpClient.client.should.have.property('defaults').and.be.an.Object()
+        httpClient.client.defaults.should.have.property('options').and.be.an.Object()
+        httpClient.client.defaults.options.should.have.property('prefixUrl', 'http://localhost:9876/api/v1/devices/my-device-1/')
+
+        // ensure proxies are not set
+        httpClient.client.defaults.options.should.have.property('agent')
+        httpClient.client.defaults.options.agent.should.have.property('http', undefined)
+        httpClient.client.defaults.options.agent.should.have.property('https', undefined)
+    })
+
+    it('Extends GOT with http proxy when env var is set', async function () {
+        sinon.stub(process, 'env').value({
+            ...process.env,
+            http_proxy: 'http://http_proxy:1234',
+            https_proxy: ''
+        })
+        const client = createHttpClient({}, {
+            forgeURL: 'http://localhost:2222',
+            token: 'token-token-2222'
+        })
+        client.should.have.property('client')
+        should(client.client.defaults.options.agent?.http).be.instanceOf(require('http-proxy-agent').HttpProxyAgent)
+        client.client.defaults.options.agent.http.proxy.should.have.property('hostname', 'http_proxy')
+        client.client.defaults.options.agent.http.proxy.should.have.property('port', '1234')
+        should(client.client.defaults.options.agent?.https).be.undefined()
+    })
+    it('Extends GOT with https proxy when env var is set', async function () {
+        sinon.stub(process, 'env').value({
+            ...process.env,
+            http_proxy: '',
+            https_proxy: 'http://https_proxy:4567'
+        })
+        const client = createHttpClient({}, {
+            forgeURL: 'http://localhost:2222',
+            token: 'token-token-2222'
+        })
+        should(client.client.defaults.options.agent?.https).be.instanceOf(require('https-proxy-agent').HttpsProxyAgent)
+        client.client.defaults.options.agent.https.proxy.should.have.property('hostname', 'https_proxy')
+        client.client.defaults.options.agent.https.proxy.should.have.property('port', '4567')
+        should(client.client.defaults.options.agent?.http).be.undefined()
+    })
+    it('Extends GOT with both http & https proxies when env vars are set', async function () {
+        sinon.stub(process, 'env').value({
+            ...process.env,
+            http_proxy: 'http://http_proxy:8888',
+            https_proxy: 'http://https_proxy:8889'
+        })
+        const client = createHttpClient({}, {
+            forgeURL: 'http://localhost:2222',
+            token: 'token-token-2222'
+        })
+        should(client.client.defaults.options.agent?.http).be.instanceOf(require('http-proxy-agent').HttpProxyAgent)
+        client.client.defaults.options.agent.http.proxy.should.have.property('hostname', 'http_proxy')
+        client.client.defaults.options.agent.http.proxy.should.have.property('port', '8888')
+        should(client.client.defaults.options.agent?.https).be.instanceOf(require('https-proxy-agent').HttpsProxyAgent)
+        client.client.defaults.options.agent.https.proxy.should.have.property('hostname', 'https_proxy')
+        client.client.defaults.options.agent.https.proxy.should.have.property('port', '8889')
+    })
+})

--- a/test/unit/lib/http_spec.js
+++ b/test/unit/lib/http_spec.js
@@ -113,6 +113,7 @@ describe('HTTP Comms', function () {
         delete process.env.http_proxy
         delete process.env.https_proxy
         delete process.env.no_proxy
+        delete process.env.all_proxy
         sinon.restore()
     })
 

--- a/test/unit/lib/http_spec.js
+++ b/test/unit/lib/http_spec.js
@@ -146,9 +146,8 @@ describe('HTTP Comms', function () {
         httpClient.client.defaults.options.should.have.property('prefixUrl', 'http://localhost:9876/api/v1/devices/my-device-1/')
 
         // ensure proxies are not set
-        httpClient.client.defaults.options.should.have.property('agent')
-        httpClient.client.defaults.options.agent.should.have.property('http', undefined)
-        httpClient.client.defaults.options.agent.should.have.property('https', undefined)
+        should(httpClient.client.defaults.options.agent?.http).be.undefined()
+        should(httpClient.client.defaults.options.agent?.https).be.undefined()
     })
 
     it('Extends GOT with http proxy when env var is set', async function () {
@@ -157,15 +156,15 @@ describe('HTTP Comms', function () {
             http_proxy: 'http://http_proxy:1234',
             https_proxy: ''
         })
-        const client = createHttpClient({}, {
+        const httpClient = createHttpClient({}, {
             forgeURL: 'http://localhost:2222',
             token: 'token-token-2222'
         })
-        client.should.have.property('client')
-        should(client.client.defaults.options.agent?.http).be.instanceOf(require('http-proxy-agent').HttpProxyAgent)
-        client.client.defaults.options.agent.http.proxy.should.have.property('hostname', 'http_proxy')
-        client.client.defaults.options.agent.http.proxy.should.have.property('port', '1234')
-        should(client.client.defaults.options.agent?.https).be.undefined()
+        httpClient.should.have.property('client')
+        should(httpClient.client.defaults.options.agent?.http).be.instanceOf(require('http-proxy-agent').HttpProxyAgent)
+        httpClient.client.defaults.options.agent.http.proxy.should.have.property('hostname', 'http_proxy')
+        httpClient.client.defaults.options.agent.http.proxy.should.have.property('port', '1234')
+        should(httpClient.client.defaults.options.agent?.https).be.undefined()
     })
     it('Extends GOT with https proxy when env var is set', async function () {
         sinon.stub(process, 'env').value({
@@ -173,14 +172,14 @@ describe('HTTP Comms', function () {
             http_proxy: '',
             https_proxy: 'http://https_proxy:4567'
         })
-        const client = createHttpClient({}, {
+        const httpClient = createHttpClient({}, {
             forgeURL: 'http://localhost:2222',
             token: 'token-token-2222'
         })
-        should(client.client.defaults.options.agent?.https).be.instanceOf(require('https-proxy-agent').HttpsProxyAgent)
-        client.client.defaults.options.agent.https.proxy.should.have.property('hostname', 'https_proxy')
-        client.client.defaults.options.agent.https.proxy.should.have.property('port', '4567')
-        should(client.client.defaults.options.agent?.http).be.undefined()
+        should(httpClient.client.defaults.options.agent?.https).be.instanceOf(require('https-proxy-agent').HttpsProxyAgent)
+        httpClient.client.defaults.options.agent.https.proxy.should.have.property('hostname', 'https_proxy')
+        httpClient.client.defaults.options.agent.https.proxy.should.have.property('port', '4567')
+        should(httpClient.client.defaults.options.agent?.http).be.undefined()
     })
     it('Extends GOT with both http & https proxies when env vars are set', async function () {
         sinon.stub(process, 'env').value({
@@ -188,15 +187,15 @@ describe('HTTP Comms', function () {
             http_proxy: 'http://http_proxy:8888',
             https_proxy: 'http://https_proxy:8889'
         })
-        const client = createHttpClient({}, {
+        const httpClient = createHttpClient({}, {
             forgeURL: 'http://localhost:2222',
             token: 'token-token-2222'
         })
-        should(client.client.defaults.options.agent?.http).be.instanceOf(require('http-proxy-agent').HttpProxyAgent)
-        client.client.defaults.options.agent.http.proxy.should.have.property('hostname', 'http_proxy')
-        client.client.defaults.options.agent.http.proxy.should.have.property('port', '8888')
-        should(client.client.defaults.options.agent?.https).be.instanceOf(require('https-proxy-agent').HttpsProxyAgent)
-        client.client.defaults.options.agent.https.proxy.should.have.property('hostname', 'https_proxy')
-        client.client.defaults.options.agent.https.proxy.should.have.property('port', '8889')
+        should(httpClient.client.defaults.options.agent?.http).be.instanceOf(require('http-proxy-agent').HttpProxyAgent)
+        httpClient.client.defaults.options.agent.http.proxy.should.have.property('hostname', 'http_proxy')
+        httpClient.client.defaults.options.agent.http.proxy.should.have.property('port', '8888')
+        should(httpClient.client.defaults.options.agent?.https).be.instanceOf(require('https-proxy-agent').HttpsProxyAgent)
+        httpClient.client.defaults.options.agent.https.proxy.should.have.property('hostname', 'https_proxy')
+        httpClient.client.defaults.options.agent.https.proxy.should.have.property('port', '8889')
     })
 })

--- a/test/unit/lib/launcher_spec.js
+++ b/test/unit/lib/launcher_spec.js
@@ -333,7 +333,7 @@ describe('Launcher', function () {
         runtimeSettings.logging.auditLogger.should.have.property('token', configWithPlatformInfo.token)
     })
 
-    describe.only('Proxy Support', function () {
+    describe('Proxy Support', function () {
         afterEach(async function () {
             delete process.env.http_proxy
             delete process.env.https_proxy

--- a/test/unit/lib/mqtt_spec.js
+++ b/test/unit/lib/mqtt_spec.js
@@ -524,7 +524,7 @@ describe('MQTT Comms', function () {
         res.error.should.have.a.property('code', 'unsupported_action')
     })
 
-    describe('Proxy', function () {
+    describe('Proxy Support', function () {
         // common variables
         const port2 = port + 1 // MQTT broker port
         /** @type {import('aedes-server-factory').Server} MQTT WS */ let httpServerProxied
@@ -563,6 +563,7 @@ describe('MQTT Comms', function () {
                 protocol: 'ws'
             })
         })
+
         after(async function () {
             mqttProxied && mqttProxied.end()
             aedesProxied.close()
@@ -579,16 +580,19 @@ describe('MQTT Comms', function () {
             sinon.restore()
         })
 
+        afterEach(async function () {
+            delete process.env.http_proxy
+            delete process.env.https_proxy
+            delete process.env.no_proxy
+        })
+
         async function mqttPubAndAwait (topic, payload, responseTopic) {
             return _mqttPubAndAwait(mqttProxied, topic, payload, responseTopic)
         }
 
         it('MQTT Comms Client does not set a proxy agent if process env does not contain proxy settings', async function () {
-            sinon.stub(process, 'env').value({
-                ...process.env,
-                http_proxy: '',
-                https_proxy: ''
-            })
+            process.env.http_proxy = ''
+            process.env.https_proxy = ''
 
             // initialise the mqtt client
             mqttClient.start()
@@ -603,11 +607,8 @@ describe('MQTT Comms', function () {
         })
 
         it('MQTT Comms Client has a HttpProxyAgent for ws connection', async function () {
-            sinon.stub(process, 'env').value({
-                ...process.env,
-                http_proxy: `http://${proxyHost}:${proxyPort}`,
-                https_proxy: `http://${proxyHost}:${proxyPort}`
-            })
+            process.env.http_proxy = `http://${proxyHost}:${proxyPort}`
+            process.env.https_proxy = `http://${proxyHost}:${proxyPort}`
 
             // initialise the mqtt client
             mqttClient.config.brokerURL = 'ws://localhost:' + port
@@ -624,11 +625,8 @@ describe('MQTT Comms', function () {
         })
 
         it('MQTT Comms Client has a HttpsProxyAgent for wss connection', async function () {
-            sinon.stub(process, 'env').value({
-                ...process.env,
-                http_proxy: `http://${proxyHost}:${proxyPort}`,
-                https_proxy: `http://${proxyHost}:${proxyPort}`
-            })
+            process.env.http_proxy = `http://${proxyHost}:${proxyPort}`
+            process.env.https_proxy = `http://${proxyHost}:${proxyPort}`
 
             // initialise the mqtt client
             mqttClient.config.brokerURL = 'wss://localhost:' + port
@@ -645,11 +643,8 @@ describe('MQTT Comms', function () {
         })
 
         it('MQTT Comms Client can connect with proxy', async function () {
-            sinon.stub(process, 'env').value({
-                ...process.env,
-                http_proxy: `http://${proxyHost}:${proxyPort}`,
-                https_proxy: `http://${proxyHost}:${proxyPort}`
-            })
+            process.env.http_proxy = `http://${proxyHost}:${proxyPort}`
+            process.env.https_proxy = `http://${proxyHost}:${proxyPort}`
 
             // start and send test message
             mqttClient.start()
@@ -673,11 +668,8 @@ describe('MQTT Comms', function () {
         })
 
         it('MQTT command gets a response when proxy is set', async function () {
-            sinon.stub(process, 'env').value({
-                ...process.env,
-                http_proxy: `http://${proxyHost}:${proxyPort}`,
-                https_proxy: `http://${proxyHost}:${proxyPort}`
-            })
+            process.env.http_proxy = `http://${proxyHost}:${proxyPort}`
+            process.env.https_proxy = `http://${proxyHost}:${proxyPort}`
 
             mqttClient.start()
 

--- a/test/unit/lib/mqtt_spec.js
+++ b/test/unit/lib/mqtt_spec.js
@@ -584,6 +584,7 @@ describe('MQTT Comms', function () {
             delete process.env.http_proxy
             delete process.env.https_proxy
             delete process.env.no_proxy
+            delete process.env.all_proxy
         })
 
         async function mqttPubAndAwait (topic, payload, responseTopic) {

--- a/test/unit/lib/mqtt_spec.js
+++ b/test/unit/lib/mqtt_spec.js
@@ -1,14 +1,21 @@
+const mocha = require('mocha') // eslint-disable-line
 const should = require('should') // eslint-disable-line
 const sinon = require('sinon')
 const path = require('path')
 const fs = require('fs/promises')
 const os = require('os')
 const Aedes = require('aedes')
-
+const { createProxy } = require('proxy')
+const HttpProxyAgent = require('http-proxy-agent').HttpProxyAgent
+const HttpsProxyAgent = require('https-proxy-agent').HttpsProxyAgent
 const { createServer } = require('aedes-server-factory')
 const MQTT = require('mqtt')
 const { MQTTClient: MQTTClientComms } = require('../../../lib/mqtt')
 const EditorTunnel = require('../../../lib/editor/tunnel')
+const port = 9800 // MQTT broker port
+const proxyPort = port + 1 // HTTP(s) proxy port for MQTT
+const proxyHost = '127.0.0.2' // works for localhost
+let currentId = 0 // incrementing id for each agent
 
 /** creates a mock Agent with sinon fakes for the methods
  * getState, setState, getCurrentFlows, getCurrentCredentials, getCurrentPackage
@@ -62,6 +69,87 @@ function createAgent (opts) {
     return newAgent()
 }
 
+/**
+ * Create a new MQTTClientComms instance
+ * @param {*} opts - lib/mqtt options
+ * @param {string} opts.team - team id
+ * @param {string} opts.device - device id
+ * @param {string} opts.project - project id
+ * @param {string} opts.snapshotId - snapshot id
+ * @param {string} opts.settingsId - settings id
+ * @param {string} opts.mode - mode
+ * @param {string} opts.editorToken - editor token
+ * @param {string} opts.state - state
+ * @param {object} opts.flows - flows
+ * @param {string} opts.credentials - credentials
+ * @param {string} opts.package - package
+ */
+function createMQTTClient (configDir, opts) {
+    opts = opts || {}
+    currentId++
+    const team = opts.team || `team${currentId}`
+    const device = opts.device || `device${currentId}`
+    const project = opts.project !== null ? `project${currentId}` : null
+    const snapshot = opts.snapshotId !== null ? { id: opts.snapshotId } : null
+    const settings = opts.settingsId !== null ? { hash: opts.settingsId } : null
+    const mode = opts.mode || 'developer'
+    const editorToken = opts.editorToken || null
+
+    const agent = createAgent({
+        currentMode: mode,
+        editorToken,
+        currentProject: project,
+        currentSettings: settings,
+        currentSnapshot: snapshot,
+        state: opts.state || 'stopped',
+        flows: opts.flows,
+        credentials: opts.credentials,
+        package: opts.package
+    })
+
+    const daMQTT = new MQTTClientComms(agent, {
+        dir: configDir,
+        forgeURL: 'http://localhost:9000',
+        brokerURL: 'ws://localhost:' + port,
+        brokerUsername: `device:${team}:${device}`,
+        brokerPassword: 'pass'
+    })
+
+    sinon.stub(daMQTT.heartbeat, 'start')
+    return daMQTT
+}
+
+async function _mqttPubAndAwait (mqttClient, topic, payload, responseTopic) {
+    return new Promise((resolve, reject) => {
+        // if timeout, reject
+        const timeOver = setTimeout(() => {
+            cleanUp()
+            reject(new Error('mqttPubAndAwait timed out'))
+        }, 500)
+        const onMessage = (topic, message) => {
+            const m = JSON.parse(message.toString())
+            // console.log('mqtt.on(message => received message %s %s', topic, m)
+            cleanUp(timeOver)
+            resolve(m)
+        }
+        const cleanUp = () => {
+            mqttClient.unsubscribe(responseTopic || topic)
+            mqttClient.off('message', onMessage)
+            clearTimeout(timeOver)
+        }
+        // if message received, resolve
+        mqttClient.subscribe(responseTopic || topic)
+        mqttClient.on('message', onMessage)
+        // publish message
+        mqttClient.publish(topic, payload, function (err) {
+            if (err) {
+                cleanUp()
+                reject(err)
+            }
+        })
+    })
+}
+
 describe('MQTT Comms', function () {
     // common variables
     /** @type {string} agent config dir */ let configDir
@@ -69,44 +157,11 @@ describe('MQTT Comms', function () {
     /** @type {Aedes} MQTT Broker */ let aedes = null
     /** @type {MQTT.MqttClient} MQTT Client */ let mqtt
     /** @type {import('../../../lib/mqtt').MQTTClient} Agent mqttClient comms */ let mqttClient = null
-    let currentId = 0 // incrementing id for each agent
+    // let currentId = 0 // incrementing id for each agent
     const sockets = {} // Maintain a hash of all connected sockets (for closing them later)
-
-    function createMQTTClient (opts) {
-        opts = opts || {}
-        currentId++
-        const team = opts.team || `team${currentId}`
-        const device = opts.device || `device${currentId}`
-        const project = opts.project !== null ? `project${currentId}` : null
-        const snapshot = opts.snapshotId !== null ? { id: opts.snapshotId } : null
-        const settings = opts.settingsId !== null ? { hash: opts.settingsId } : null
-        const mode = opts.mode || 'developer'
-        const editorToken = opts.editorToken || null
-
-        const agent = createAgent({
-            currentMode: mode,
-            editorToken,
-            currentProject: project,
-            currentSettings: settings,
-            currentSnapshot: snapshot,
-            state: opts.state || 'stopped',
-            flows: opts.flows,
-            credentials: opts.credentials,
-            package: opts.package
-        })
-
-        return new MQTTClientComms(agent, {
-            dir: configDir,
-            forgeURL: 'http://localhost:9000',
-            brokerURL: 'ws://localhost:9800',
-            brokerUsername: `device:${team}:${device}`,
-            brokerPassword: 'pass'
-        })
-    }
 
     before(async function () {
         aedes = new Aedes()
-        const port = 9800
         httpServer = createServer(aedes, { ws: true })
         httpServer.listen(port, function () {
             // console.log('websocket server listening on port ', port)
@@ -164,7 +219,7 @@ describe('MQTT Comms', function () {
     beforeEach(async function () {
         configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ff-launcher-'))
         await fs.mkdir(path.join(configDir, 'project'))
-        mqttClient = createMQTTClient()
+        mqttClient = createMQTTClient(configDir)
         sinon.stub(console, 'log') // hush console.log
         sinon.stub(console, 'info') // hush console.info
     })
@@ -175,37 +230,13 @@ describe('MQTT Comms', function () {
         mqttClient = null
         console.log.restore()
         console.info.restore()
+        if (process.env.restore) {
+            process.env.restore()
+        }
     })
 
     async function mqttPubAndAwait (topic, payload, responseTopic) {
-        return new Promise((resolve, reject) => {
-            // if timeout, reject
-            const timeOver = setTimeout(() => {
-                cleanUp()
-                reject(new Error('mqttPubAndAwait timed out'))
-            }, 500)
-            const onMessage = (topic, message) => {
-                const m = JSON.parse(message.toString())
-                // console.log('mqtt.on(message => received message %s %s', topic, m)
-                cleanUp(timeOver)
-                resolve(m)
-            }
-            const cleanUp = () => {
-                mqtt.unsubscribe(responseTopic || topic)
-                mqtt.off('message', onMessage)
-                clearTimeout(timeOver)
-            }
-            // if message received, resolve
-            mqtt.subscribe(responseTopic || topic)
-            mqtt.on('message', onMessage)
-            // publish message
-            mqtt.publish(topic, payload, function (err) {
-                if (err) {
-                    cleanUp()
-                    reject(err)
-                }
-            })
-        })
+        return _mqttPubAndAwait(mqtt, topic, payload, responseTopic)
     }
 
     it('Creates the MQTT Comms Client', async function () {
@@ -491,5 +522,192 @@ describe('MQTT Comms', function () {
         res.should.have.a.property('success', false)
         res.should.have.a.property('error').and.be.an.Object()
         res.error.should.have.a.property('code', 'unsupported_action')
+    })
+
+    describe('Proxy', function () {
+        // common variables
+        const port2 = port + 1 // MQTT broker port
+        /** @type {import('aedes-server-factory').Server} MQTT WS */ let httpServerProxied
+        /** @type {Aedes} MQTT Broker */ let aedesProxied = null
+        /** @type {MQTT.MqttClient} MQTT Client */ let mqttProxied
+
+        before(async function () {
+            aedesProxied = new Aedes()
+            httpServerProxied = createProxy(createServer(aedesProxied, { ws: true }))
+            httpServerProxied.localAddress = '127.0.0.99' // REF: https://gist.github.com/ttodua/7a66e5ca28e55deebc58b0dd8e0c39a2
+            httpServerProxied.listen(proxyPort, proxyHost, function () {
+                // console.log('websocket server listening on port ', port2)
+            })
+            let nextSocketId = 0
+            httpServerProxied.on('connection', function (socket) {
+                // Add a newly connected socket
+                const socketId = nextSocketId++
+                sockets[socketId] = socket
+                // console.log('socket', socketId, 'opened')
+
+                // Remove the socket when it closes
+                socket.on('close', function () {
+                    // console.log('socket', socketId, 'closed')
+                    delete sockets[socketId]
+                })
+            })
+            const agent = new HttpProxyAgent('http://' + proxyHost + ':' + proxyPort)
+
+            mqttProxied = MQTT.connect(`ws://localhost:${port2}`, {
+                wsOptions: {
+                    agent
+                },
+                clientId: 'testsuite-' + Date.now(),
+                username: 'device:team:device',
+                password: 'pass',
+                protocol: 'ws'
+            })
+        })
+        after(async function () {
+            mqttProxied && mqttProxied.end()
+            aedesProxied.close()
+            aedesProxied.removeAllListeners()
+            if (httpServerProxied) {
+                // Close the server
+                httpServerProxied.close(function () { /* console.log('Server closed!') */ })
+                // Destroy all open sockets
+                for (const socketId in sockets) {
+                    // console.log('socket', socketId, 'destroyed')
+                    sockets[socketId].destroy()
+                }
+            }
+            sinon.restore()
+        })
+
+        async function mqttPubAndAwait (topic, payload, responseTopic) {
+            return _mqttPubAndAwait(mqttProxied, topic, payload, responseTopic)
+        }
+
+        it('MQTT Comms Client does not set a proxy agent if process env does not contain proxy settings', async function () {
+            sinon.stub(process, 'env').value({
+                ...process.env,
+                http_proxy: '',
+                https_proxy: ''
+            })
+
+            // initialise the mqtt client
+            mqttClient.start()
+
+            // the client and agent should have been created without proxy agent settings
+            mqttClient.should.have.a.property('client').and.be.an.Object()
+            mqttClient.client.options.hostname.should.equal('localhost')
+            mqttClient.client.options.port.should.equal(port)
+
+            mqttClient.brokerConfig.should.not.have.a.property('wsOptions')
+            mqttClient.client.options.wsOptions.should.not.have.a.property('agent')
+        })
+
+        it('MQTT Comms Client has a HttpProxyAgent for ws connection', async function () {
+            sinon.stub(process, 'env').value({
+                ...process.env,
+                http_proxy: `http://${proxyHost}:${proxyPort}`,
+                https_proxy: `http://${proxyHost}:${proxyPort}`
+            })
+
+            // initialise the mqtt client
+            mqttClient.config.brokerURL = 'ws://localhost:' + port
+            mqttClient.start()
+
+            // the client and agent should have been created without proxy agent settings
+            mqttClient.should.have.a.property('client').and.be.an.Object()
+            mqttClient.client.options.hostname.should.equal('localhost')
+            mqttClient.client.options.port.should.equal(port)
+
+            mqttClient.brokerConfig.should.have.a.property('wsOptions')
+            mqttClient.brokerConfig.wsOptions.should.have.a.property('agent').and.be.an.Object()
+            should(mqttClient.brokerConfig.wsOptions.agent instanceof HttpProxyAgent).be.true()
+        })
+
+        it('MQTT Comms Client has a HttpsProxyAgent for wss connection', async function () {
+            sinon.stub(process, 'env').value({
+                ...process.env,
+                http_proxy: `http://${proxyHost}:${proxyPort}`,
+                https_proxy: `http://${proxyHost}:${proxyPort}`
+            })
+
+            // initialise the mqtt client
+            mqttClient.config.brokerURL = 'wss://localhost:' + port
+            mqttClient.start()
+
+            // the client and agent should have been created without proxy agent settings
+            mqttClient.should.have.a.property('client').and.be.an.Object()
+            mqttClient.client.options.hostname.should.equal('localhost')
+            mqttClient.client.options.port.should.equal(port)
+
+            mqttClient.brokerConfig.should.have.a.property('wsOptions')
+            mqttClient.brokerConfig.wsOptions.should.have.a.property('agent').and.be.an.Object()
+            should(mqttClient.brokerConfig.wsOptions.agent instanceof HttpsProxyAgent).be.true()
+        })
+
+        it('MQTT Comms Client can connect with proxy', async function () {
+            sinon.stub(process, 'env').value({
+                ...process.env,
+                http_proxy: `http://${proxyHost}:${proxyPort}`,
+                https_proxy: `http://${proxyHost}:${proxyPort}`
+            })
+
+            // start and send test message
+            mqttClient.start()
+
+            // the client and agent should have been created with the correct settings
+            mqttClient.should.have.a.property('client').and.be.an.Object()
+            mqttClient.client.options.hostname.should.equal('localhost')
+            mqttClient.client.options.port.should.equal(port)
+
+            mqttClient.brokerConfig.should.have.a.property('wsOptions').and.be.an.Object()
+            mqttClient.brokerConfig.wsOptions.should.have.a.property('agent').and.be.an.Object()
+            mqttClient.client.options.should.have.a.property('wsOptions').and.be.an.Object()
+            mqttClient.client.options.wsOptions.should.have.a.property('agent').and.be.an.Object()
+            mqttClient.client.options.wsOptions.agent.proxy.hostname.should.equal(proxyHost)
+            mqttClient.client.options.wsOptions.agent.proxy.port.should.equal('' + proxyPort)
+
+            // a short async delay to permit mqtt to connect
+            await new Promise(resolve => setTimeout(resolve, 500))
+
+            mqttClient.client.connected.should.be.true()
+        })
+
+        it('MQTT command gets a response when proxy is set', async function () {
+            sinon.stub(process, 'env').value({
+                ...process.env,
+                http_proxy: `http://${proxyHost}:${proxyPort}`,
+                https_proxy: `http://${proxyHost}:${proxyPort}`
+            })
+
+            mqttClient.start()
+
+            const commandTopic = `ff/v1/${mqttClient.teamId}/d/${mqttClient.deviceId}/command`
+            const responseTopic = `ff/v1/${mqttClient.teamId}/d/${mqttClient.deviceId}/response`
+            // console.log('commandTopic', commandTopic)
+            // console.log('responseTopic', responseTopic)
+            mqttClient.should.have.a.property('client').and.be.an.Object()
+            mqttClient.should.have.a.property('commandTopic').and.be.a.String().and.equal(commandTopic)
+            mqttClient.should.have.a.property('responseTopic').and.be.a.String().and.equal(responseTopic)
+
+            const payload = {
+                command: 'startEditor',
+                correlationData: 'correlationData-test',
+                responseTopic,
+                payload: {
+                    token: 'token-test'
+                }
+            }
+            const payloadStr = JSON.stringify(payload)
+
+            // short delay to allow mqtt to connect and stack to unwind
+            await new Promise(resolve => setTimeout(resolve, 500))
+            const response = await mqttPubAndAwait(commandTopic, payloadStr, responseTopic)
+            await new Promise(resolve => setTimeout(resolve, 50))
+            response.should.have.a.property('command', 'startEditor')
+            response.should.have.a.property('correlationData', 'correlationData-test')
+            response.should.have.a.property('payload').and.be.an.Object()
+            response.payload.should.have.a.property('connected', false)
+            response.payload.should.have.a.property('token', 'token-test')
+        })
     })
 })

--- a/test/unit/lib/plugins/libraryPlugin_spec.js
+++ b/test/unit/lib/plugins/libraryPlugin_spec.js
@@ -73,6 +73,7 @@ describe('FFTeamLibraryPlugin', () => {
             delete process.env.http_proxy
             delete process.env.https_proxy
             delete process.env.no_proxy
+            delete process.env.all_proxy
         })
         it('should create an instance with valid configuration and no proxy', () => {
             const config = {

--- a/test/unit/lib/plugins/libraryPlugin_spec.js
+++ b/test/unit/lib/plugins/libraryPlugin_spec.js
@@ -1,0 +1,169 @@
+const mocha = require('mocha') // eslint-disable-line
+const should = require('should') // eslint-disable-line
+const sinon = require('sinon') // eslint-disable-line
+const HttpProxyAgent = require('http-proxy-agent').HttpProxyAgent
+const HttpsProxyAgent = require('https-proxy-agent').HttpsProxyAgent
+const pluginModule = require('../../../../lib/plugins/node_modules/@flowforge/flowforge-library-plugin/libraryPlugin.js')
+let FFTeamLibraryPluginClass = null
+
+// simulate RED object to capture the plugin class for performing unit tests on the internal plugin
+const RED = {
+    plugins: {
+        registerPlugin: function (PLUGIN_TYPE_ID, plugin) {
+            FFTeamLibraryPluginClass = plugin.class
+        }
+    }
+}
+pluginModule(RED)
+
+describe('FFTeamLibraryPlugin', () => {
+    it('should throw an error if projectID and applicationID are missing', () => {
+        const config = {
+            id: 'plugin-id',
+            label: 'Plugin Label',
+            libraryID: 'library-id',
+            token: 'token'
+        }
+
+        const expectError = 'Missing required configuration property: projectID or applicationID are required'
+        try {
+            new FFTeamLibraryPluginClass(config) // eslint-disable-line
+            should.fail('Should have thrown a "Missing required configuration property" error')
+        } catch (error) {
+            should(error.message).be.eql(expectError)
+        }
+    })
+
+    it('should throw an error if libraryID is missing', () => {
+        const config = {
+            id: 'plugin-id',
+            label: 'Plugin Label',
+            projectID: 'project-id',
+            token: 'token'
+        }
+
+        const expectError = 'Missing required configuration property: libraryID'
+        try {
+            new FFTeamLibraryPluginClass(config) // eslint-disable-line
+            should.fail('Should have thrown a "Missing required configuration property" error')
+        } catch (error) {
+            should(error.message).be.eql(expectError)
+        }
+    })
+
+    it('should throw an error if token is missing', () => {
+        const config = {
+            id: 'plugin-id',
+            label: 'Plugin Label',
+            projectID: 'project-id',
+            libraryID: 'library-id'
+        }
+
+        const expectError = 'Missing required configuration property: token'
+        try {
+            new FFTeamLibraryPluginClass(config) // eslint-disable-line
+            should.fail('Should have thrown a "Missing required configuration property" error')
+        } catch (error) {
+            should(error.message).be.eql(expectError)
+        }
+    })
+
+    it('should create an instance with valid configuration and no proxy', () => {
+        const config = {
+            id: 'plugin-id',
+            label: 'Plugin Label',
+            projectID: 'project-id',
+            libraryID: 'library-id',
+            token: 'token',
+            baseURL: 'https://example.com'
+        }
+
+        const plugin = new FFTeamLibraryPluginClass(config)
+
+        should(plugin).be.instanceOf(FFTeamLibraryPluginClass)
+        should(plugin.type).be.eql('flowfuse-team-library')
+        should(plugin.id).be.eql('plugin-id')
+        should(plugin.label).be.eql('Plugin Label')
+        should(plugin._client)
+        should(plugin._client.defaults).be.an.Object()
+        should(plugin._client.defaults.options).be.an.Object()
+
+        plugin._client.defaults.options.prefixUrl.should.be.eql('https://example.com/library/library-id/')
+        plugin._client.defaults.options.headers['user-agent'].should.be.eql('FlowFuse HTTP Storage v0.1')
+        plugin._client.defaults.options.headers.authorization.should.be.eql('Bearer token')
+        plugin._client.defaults.options.timeout.request.should.be.eql(10000)
+        should(plugin._client.defaults.options.agent?.http).be.undefined()
+        should(plugin._client.defaults.options.agent?.https).be.undefined()
+    })
+
+    it('should extend got to use http proxy when env var http_proxy is set', () => {
+        sinon.stub(process, 'env').value({
+            ...process.env,
+            http_proxy: 'http://http_proxy:1234',
+            https_proxy: ''
+        })
+
+        const config = {
+            id: 'plugin-id',
+            label: 'Plugin Label',
+            projectID: 'project-id',
+            libraryID: 'library-id',
+            token: 'token',
+            baseURL: 'https://example.com'
+        }
+
+        const plugin = new FFTeamLibraryPluginClass(config)
+        should(plugin).be.instanceOf(FFTeamLibraryPluginClass)
+        should(plugin._client.defaults.options.agent.https).be.undefined()
+        plugin._client.defaults.options.agent.should.have.property('http').and.be.instanceOf(HttpProxyAgent)
+        plugin._client.defaults.options.agent.http.should.have.property('proxy').and.be.an.Object()
+        plugin._client.defaults.options.agent.http.proxy.should.have.property('hostname', 'http_proxy')
+        plugin._client.defaults.options.agent.http.proxy.should.have.property('port', '1234')
+    })
+
+    it('should extend got to use https proxy when env var https_proxy is set', () => {
+        sinon.stub(process, 'env').value({
+            ...process.env,
+            http_proxy: '',
+            https_proxy: 'http://https_proxy:4567'
+        })
+
+        const config = {
+            id: 'plugin-id',
+            label: 'Plugin Label',
+            projectID: 'project-id',
+            libraryID: 'library-id',
+            token: 'token',
+            baseURL: 'https://example.com'
+        }
+
+        const plugin = new FFTeamLibraryPluginClass(config)
+        should(plugin).be.instanceOf(FFTeamLibraryPluginClass)
+        should(plugin._client.defaults.options.agent.http).be.undefined()
+        plugin._client.defaults.options.agent.should.have.property('https').and.be.instanceOf(HttpsProxyAgent)
+        plugin._client.defaults.options.agent.https.should.have.property('proxy')
+        plugin._client.defaults.options.agent.https.proxy.should.have.property('hostname', 'https_proxy')
+        plugin._client.defaults.options.agent.https.proxy.should.have.property('port', '4567')
+    })
+    it('should extend got to use http & https proxies when env vars are set', () => {
+        sinon.stub(process, 'env').value({
+            ...process.env,
+            http_proxy: 'http://https_proxy:1234',
+            https_proxy: 'http://https_proxy:4567'
+        })
+
+        const config = {
+            id: 'plugin-id',
+            label: 'Plugin Label',
+            projectID: 'project-id',
+            libraryID: 'library-id',
+            token: 'token',
+            baseURL: 'https://example.com'
+        }
+
+        const plugin = new FFTeamLibraryPluginClass(config)
+        should(plugin).be.instanceOf(FFTeamLibraryPluginClass)
+        plugin._client.defaults.options.agent.should.have.property('http').and.be.instanceOf(HttpProxyAgent)
+        plugin._client.defaults.options.agent.should.have.property('https').and.be.instanceOf(HttpsProxyAgent)
+    })
+})

--- a/test/unit/lib/template-settings_spec.js
+++ b/test/unit/lib/template-settings_spec.js
@@ -191,6 +191,7 @@ describe('template-settings', () => {
             delete process.env.http_proxy
             delete process.env.https_proxy
             delete process.env.no_proxy
+            delete process.env.all_proxy
         })
 
         it('should not extend got when env vars http(s)_proxy are not set', async function () {

--- a/test/unit/lib/template-settings_spec.js
+++ b/test/unit/lib/template-settings_spec.js
@@ -1,0 +1,296 @@
+const mocha = require('mocha') // eslint-disable-line
+const should = require('should')
+const sinon = require('sinon')
+const rewire = require('rewire')
+const { newLauncher } = require('../../../lib/launcher')
+const fs = require('fs/promises')
+const path = require('path')
+const os = require('os')
+const setup = require('../setup')
+const { default: got } = require('got')
+const HttpProxyAgent = require('http-proxy-agent').HttpProxyAgent
+const HttpsProxyAgent = require('https-proxy-agent').HttpsProxyAgent
+
+describe('template-settings', () => {
+    /** @type {sinon.SinonSandbox} */
+    let sandbox
+    let settingsFilePath
+    let projectPath
+    const config = {
+        forgeURL: 'https://forge.flowfuse.io',
+        credentialSecret: 'secret',
+        port: 1880,
+        dir: '',
+        verbose: true
+    }
+    async function generateSettingsFile (_config) {
+        _config = Object.assign({}, config, _config)
+        const launcher = newLauncher({ config: _config }, null, 'PROJECTID', setup.snapshot)
+        await launcher.writeSettings()
+        settingsFilePath = path.join(config.dir, 'project', 'settings.js')
+        return settingsFilePath
+    }
+    beforeEach(async function () {
+        sandbox = sinon.createSandbox()
+        // shush the console
+        sandbox.stub(console, 'log')
+        config.dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ff-launcher-'))
+        projectPath = path.join(config.dir, 'project')
+        await fs.mkdir(projectPath)
+        // since we will be loading the generated template+settings, we need to simlink the
+        // node_modules to the project directory (so it can pick up ant requires in the settings.js file)
+        await fs.symlink(path.join(__dirname, '..', '..', '..', 'node_modules'), path.join(projectPath, 'node_modules'), 'dir')
+        // clear any proxy settings
+        process.env.http_proxy = ''
+        process.env.https_proxy = ''
+    })
+
+    afterEach(async function () {
+        sandbox.restore()
+        try {
+            await fs.rm(config.dir, { recursive: true, force: true })
+        } catch (_error) {
+        }
+    })
+
+    it('should load default settings', async function () {
+        const settingsFile = await generateSettingsFile()
+        const settings = require(settingsFile)
+        should.exist(settings)
+        settings.should.have.a.property('adminAuth').and.be.an.Object()
+        settings.adminAuth.should.have.a.property('type', 'credentials')
+        settings.adminAuth.should.have.a.property('users').and.be.a.Function()
+        settings.adminAuth.should.have.a.property('authenticate').and.be.a.Function()
+        settings.adminAuth.should.have.a.property('tokens').and.be.a.Function()
+
+        settings.should.have.a.property('contextStorage').and.be.an.Object()
+        settings.contextStorage.should.have.a.property('default', 'memory')
+        settings.contextStorage.should.have.a.property('memory').and.be.an.Object()
+        settings.contextStorage.memory.should.have.a.property('module', 'memory')
+        settings.contextStorage.should.have.a.property('persistent').and.be.an.Object()
+        settings.contextStorage.persistent.should.have.a.property('module', 'localfilesystem')
+
+        settings.should.have.a.property('credentialSecret', 'secret')
+        settings.should.have.a.property('disableEditor', false)
+
+        settings.should.have.a.property('editorTheme').and.be.an.Object()
+        settings.editorTheme.theme.should.equal('forge-light')
+        settings.editorTheme.should.have.a.property('codeEditor').and.be.an.Object()
+        settings.editorTheme.codeEditor.should.have.a.property('lib', 'monaco')
+        settings.editorTheme.tours.should.be.false()
+        settings.editorTheme.should.have.a.property('palette').and.be.an.Object()
+
+        settings.should.have.a.property('externalModules').and.be.an.Object()
+        settings.externalModules.should.have.a.property('autoInstall', true)
+        settings.externalModules.should.have.a.property('palette').and.be.an.Object()
+        settings.externalModules.palette.should.have.a.property('allowInstall', true)
+        settings.externalModules.should.have.a.property('modules').and.be.an.Object()
+        settings.externalModules.modules.should.have.a.property('allowInstall', true)
+
+        settings.should.have.a.property('flowFile', 'flows.json')
+
+        settings.should.have.a.property('flowforge').and.be.an.Object()
+        settings.flowforge.should.have.a.property('auditLogger').and.be.an.Object()
+        settings.flowforge.auditLogger.should.have.a.property('bin')
+        settings.flowforge.auditLogger.should.have.a.property('url')
+        settings.flowforge.should.have.a.property('projectID', 'PROJECTID')
+
+        settings.should.have.a.property('forge-light').and.be.an.Object()
+        settings['forge-light'].should.have.a.property('projectURL').and.be.a.String()
+
+        settings.should.have.a.property('httpAdminRoot', 'device-editor')
+        settings.should.have.a.property('httpNodeCors').and.be.an.Object()
+        settings.httpNodeCors.should.have.a.property('origin', '*')
+        settings.httpNodeCors.should.have.a.property('methods', 'GET,PUT,POST,DELETE')
+        settings.should.have.a.property('uiHost', '0.0.0.0')
+        settings.should.have.a.property('uiPort', 1880)
+
+        settings.should.have.a.property('logging').and.be.an.Object()
+        settings.logging.should.have.a.property('auditLogger').and.be.an.Object()
+        settings.logging.auditLogger.should.have.a.property('audit', true)
+        settings.logging.auditLogger.should.have.a.property('handler').and.be.a.Function()
+        settings.logging.auditLogger.should.have.a.property('level', 'off')
+        settings.logging.auditLogger.should.have.a.property('loggingURL')
+        settings.logging.auditLogger.should.have.a.property('token')
+
+        settings.logging.should.have.a.property('console').and.be.an.Object()
+        settings.logging.console.should.have.a.property('level', 'info')
+        settings.logging.console.should.have.a.property('metric', false)
+        settings.logging.console.should.have.a.property('audit', false)
+        settings.logging.console.should.have.a.property('handler').and.be.a.Function()
+        settings.should.have.a.property('nodesDir', null)
+    })
+
+    it('should call got.get with the correct parameters when verifying token', async function () {
+        const settingsFile = await generateSettingsFile()
+        const settings = rewire(settingsFile) // using rewire instead of require so we can access internal variables
+        should.exist(settings)
+
+        // normally got is loaded the first time tokens() is called but for test purposes we
+        // need to load it here first so that we can stub the get method
+        /** @type {import('got').default} */
+        const _got = got.extend({})
+        settings.__set__('got', _got) // update the internal got instance with this one
+        sandbox.stub(_got, 'get').resolves({ body: JSON.stringify({ username: 'test', permissions: ['read'] }) })
+
+        await settings.adminAuth.tokens('ffde_123456')
+
+        _got.get.calledOnce.should.be.true()
+        _got.get.calledWith(`${settings.flowforge.forgeURL}/api/v1/devices/123456/editor/token`, {
+            timeout: { request: 2000 },
+            headers: {
+                'user-agent': 'FlowFuse Device Agent Node-RED admin auth',
+                'x-access-token': 'ffde_123456'
+            }
+        }).should.be.true()
+    })
+
+    it('should cache the token verification result for subsequent calls within 30 seconds', async function () {
+        const settingsFile = await generateSettingsFile()
+        const settings = rewire(settingsFile) // using rewire instead of require so we can access internal variables
+        should.exist(settings)
+
+        // normally got is loaded the first time tokens() is called but for test purposes we
+        // need to load it here first so that we can stub the get method
+        /** @type {import('got').default} */
+        const _got = got.extend({})
+        settings.__set__('got', _got) // update the internal got instance with this one
+        sandbox.stub(_got, 'get').resolves({ body: JSON.stringify({ username: 'test', permissions: ['read'] }) })
+
+        await settings.adminAuth.tokens('ffde_123456')
+        await settings.adminAuth.tokens('ffde_123456')
+        await settings.adminAuth.tokens('ffde_123456')
+
+        _got.get.calledOnce.should.be.true()
+    })
+
+    it('should not extend got when env vars http(s)_proxy are not set', async function () {
+        process.env.http_proxy = ''
+        process.env.https_proxy = ''
+
+        const settingsFile = await generateSettingsFile()
+        const settings = rewire(settingsFile) // using rewire instead of require so we can access internal variables
+        should.exist(settings)
+
+        // normally got is loaded the first time tokens() is called but for test purposes we
+        // need to load it here first so that we can stub the get method
+        /** @type {import('got').default} */
+        const _got = got.extend({})
+        settings.__set__('got', _got) // update the internal got instance with this one
+        sandbox.stub(_got, 'get').resolves({ body: JSON.stringify({ username: 'test', permissions: ['read'] }) })
+
+        await settings.adminAuth.tokens('ffde_123456')
+
+        _got.get.calledOnce.should.be.true()
+        should(_got.defaults.options.agent).be.undefined()
+    })
+    it('should extend got to use http proxy when env var http_proxy is set', async function () {
+        // since got gets extended when tokens() is called and a http_proxy is set in the env
+        // we need to increase the timeout for this test. Reason being that got.extend replaces
+        // the got instance so pre-initialising it and stubbing the get method does not work!
+        // Instead, we have to call it twice and let the first call simply fail then when it
+        // returns, we can stub the get method and try again
+        this.timeout(5000) // template-settings.js tokens() has a 2000ms timeout
+
+        process.env.http_proxy = 'http://localhost:1234'
+        process.env.https_proxy = ''
+
+        const settingsFile = await generateSettingsFile()
+        const settings = rewire(settingsFile) // using rewire instead of require so we can access internal variables
+        should.exist(settings)
+
+        // normally got is loaded the first time tokens() is called but for test purposes we
+        // need to load it here first so that we can stub the get method
+        /** @type {import('got').default} */
+        const _got = got.extend({})
+        settings.__set__('got', _got) // update the internal got instance with this one
+        sandbox.stub(_got, 'get').resolves({ body: JSON.stringify({ username: 'test', permissions: ['read'] }) })
+
+        await settings.adminAuth.tokens('ffde_123456') // first call initializes got, now we can stub the get method
+        const extendedGot = settings.__get__('got')
+        sandbox.stub(extendedGot, 'get').resolves({ body: JSON.stringify({ username: 'test', permissions: ['read'] }) })
+        await settings.adminAuth.tokens('ffde_123456')
+
+        extendedGot.get.calledOnce.should.be.true()
+        should(extendedGot.defaults.options.agent?.http).be.instanceOf(HttpProxyAgent)
+        extendedGot.defaults.options.agent.http.should.have.property('proxy').and.be.an.Object()
+        extendedGot.defaults.options.agent.http.proxy.should.have.property('hostname', 'localhost')
+        extendedGot.defaults.options.agent.http.proxy.should.have.property('port', '1234')
+        should(extendedGot.defaults.options.agent?.https).be.undefined()
+    })
+
+    it('should extend got to use https proxy when env var https_proxy is set', async function () {
+        // since got gets extended when tokens() is called and a https_proxy is set in the env
+        // we need to increase the timeout for this test. Reason being that got.extend replaces
+        // the got instance so pre-initialising it and stubbing the get method does not work!
+        // Instead, we have to call it twice and let the first call simply fail then when it
+        // returns, we can stub the get method and try again
+        this.timeout(5000) // template-settings.js tokens() has a 2000ms timeout
+
+        process.env.http_proxy = ''
+        process.env.https_proxy = 'http://localhost:7654'
+
+        const settingsFile = await generateSettingsFile()
+        const settings = rewire(settingsFile) // using rewire instead of require so we can access internal variables
+        should.exist(settings)
+
+        // normally got is loaded the first time tokens() is called but for test purposes we
+        // need to load it here first so that we can stub the get method
+        /** @type {import('got').default} */
+        const _got = got.extend({})
+        settings.__set__('got', _got) // update the internal got instance with this one
+        sandbox.stub(_got, 'get').resolves({ body: JSON.stringify({ username: 'test', permissions: ['read'] }) })
+
+        await settings.adminAuth.tokens('ffde_123456') // first call initializes got, now we can stub the get method
+        const extendedGot = settings.__get__('got')
+        sandbox.stub(extendedGot, 'get').resolves({ body: JSON.stringify({ username: 'test', permissions: ['read'] }) })
+        await settings.adminAuth.tokens('ffde_123456')
+
+        extendedGot.defaults.options.agent.should.have.property('https')
+        should(extendedGot.defaults.options.agent?.https).be.instanceOf(HttpsProxyAgent)
+        extendedGot.defaults.options.agent.https.should.have.property('proxy')
+        extendedGot.defaults.options.agent.https.proxy.should.have.property('hostname', 'localhost')
+        extendedGot.defaults.options.agent.https.proxy.should.have.property('port', '7654')
+        should(extendedGot.defaults.options.agent?.http).be.undefined()
+    })
+
+    it('should extend got to use http & https proxies when env vars are set', async function () {
+        this.timeout(5000) // increase timeout of this test as the underlying http call will fail (tokens() has a 2000ms timeout)
+
+        process.env.http_proxy = 'http://localhost:4567'
+        process.env.https_proxy = 'http://localhost:7654'
+
+        const settingsFile = await generateSettingsFile()
+        const settings = rewire(settingsFile) // using rewire instead of require so we can access internal variables
+        should.exist(settings)
+
+        await settings.adminAuth.tokens('ffde_123456') // calling tokens() initializes got
+        const extendedGot = settings.__get__('got')
+
+        extendedGot.defaults.options.agent.should.have.property('https').and.be.instanceOf(HttpsProxyAgent)
+        extendedGot.defaults.options.agent.should.have.property('http').and.be.instanceOf(HttpProxyAgent)
+    })
+    it.skip('should not cache invalid token', async function () {
+        // TODO: Implement test
+    })
+
+    it.skip('should return without hitting cache or API if the token is not valid', async function () {
+        // TODO: Implement test
+    })
+
+    it.skip('should return null for the users function', async function () {
+        // TODO: Implement test
+    })
+
+    it.skip('should return null for the authenticate function', async function () {
+        // TODO: Implement test
+    })
+
+    it.skip('should set the https options if provided', async function () {
+        // TODO: Implement test
+    })
+
+    it.skip('should set the httpStatic option if provided', async function () {
+        // TODO: Implement test
+    })
+})

--- a/test/unit/lib/util_spec.js
+++ b/test/unit/lib/util_spec.js
@@ -111,22 +111,26 @@ describe('utils', function () {
             delete process.env.http_proxy
             delete process.env.https_proxy
             delete process.env.no_proxy
+            delete process.env.all_proxy
         })
         it('should return null when there are no env vars set', function () {
             delete process.env.http_proxy
             delete process.env.https_proxy
             delete process.env.no_proxy
+            delete process.env.all_proxy
             should(utils.getWSProxyAgent('ws://test.com')).be.null()
             should(utils.getWSProxyAgent('wss://test.com')).be.null()
         })
         it('should not proxy any requests if they are excluded by no_local', function () {
             process.env.http_proxy = 'http://proxy:3128'
             process.env.https_proxy = 'http://proxy:3128'
+            process.env.all_proxy = 'http://proxy:3128'
             process.env.no_proxy = 'test.com'
             should(utils.getWSProxyAgent('ws://test.com')).be.null()
             should(utils.getWSProxyAgent('wss://test.com')).be.null()
             process.env.http_proxy = 'http://proxy:3128'
             process.env.https_proxy = 'http://proxy:3128'
+            process.env.all_proxy = 'http://proxy:3128'
             process.env.no_proxy = '192.168.0.100'
             should(utils.getWSProxyAgent('ws://192.168.0.100')).be.null()
             should(utils.getWSProxyAgent('wss://192.168.0.100')).be.null()
@@ -150,6 +154,24 @@ describe('utils', function () {
             agent.should.have.property('proxy')
             agent.proxy.should.have.property('hostname', 'proxy')
             agent.proxy.should.have.property('port', '3128')
+        })
+        it('should return a HttpProxyAgent when all_proxy is set and the URL is ws://', function () {
+            const url = 'ws://test.com'
+            process.env.http_proxy = ''
+            process.env.https_proxy = ''
+            process.env.all_proxy = 'https://all_proxy:7777'
+            const agent = utils.getWSProxyAgent(url, { timeout: 4444 })
+            agent.proxy.should.have.property('hostname', 'all_proxy')
+            agent.proxy.should.have.property('port', '7777')
+        })
+        it('should return a HttpsProxyAgent when all_proxy is set and the URL is wss://', function () {
+            const url = 'wss://test.com'
+            process.env.http_proxy = ''
+            process.env.https_proxy = ''
+            process.env.all_proxy = 'https://all_proxy:8888'
+            const agent = utils.getWSProxyAgent(url, { timeout: 4444 })
+            agent.proxy.should.have.property('hostname', 'all_proxy')
+            agent.proxy.should.have.property('port', '8888')
         })
         it('should set http proxy options', function () {
             const url = 'ws://test.com'
@@ -265,6 +287,24 @@ describe('utils', function () {
             agent.https.should.have.property('proxy')
             agent.https.proxy.should.have.property('hostname', 'proxy')
             agent.https.proxy.should.have.property('port', '8080')
+        })
+        it('should use all_proxy to set http proxy options', function () {
+            process.env.http_proxy = ''
+            process.env.https_proxy = ''
+            process.env.all_proxy = 'http://all_proxy:7777'
+            const agent = utils.getHTTPProxyAgent('http://127.0.0.1:3000')
+            agent.http.should.have.property('proxy')
+            agent.http.proxy.should.have.property('hostname', 'all_proxy')
+            agent.http.proxy.should.have.property('port', '7777')
+        })
+        it('should use all_proxy to set https proxy options', function () {
+            process.env.http_proxy = ''
+            process.env.https_proxy = ''
+            process.env.all_proxy = 'http://all_proxy:8888'
+            const agent = utils.getHTTPProxyAgent('https://127.0.0.1:3000')
+            agent.https.should.have.property('proxy')
+            agent.https.proxy.should.have.property('hostname', 'all_proxy')
+            agent.https.proxy.should.have.property('port', '8888')
         })
         it('should set http proxy options', function () {
             process.env.http_proxy = 'http://proxy:8080'

--- a/test/unit/lib/util_spec.js
+++ b/test/unit/lib/util_spec.js
@@ -103,4 +103,92 @@ describe('utils', function () {
             utils.compareNodeRedData({ modules: { 'node-red': 'latest' } }, { modules: undefined }).should.be.false()
         })
     })
+    describe('getWSProxyAgent', function () {
+        const HttpProxyAgent = require('http-proxy-agent').HttpProxyAgent
+        const HttpsProxyAgent = require('https-proxy-agent').HttpsProxyAgent
+
+        it('should return null for no proxy', function () {
+            process.env.http_proxy = ''
+            process.env.https_proxy = ''
+            should(utils.getWSProxyAgent('ws://test.com')).be.null()
+            should(utils.getWSProxyAgent('wss://test.com')).be.null()
+        })
+        it('should return a HttpProxyAgent when http_proxy is set and the URL is ws://', function () {
+            const url = 'ws://test.com'
+            process.env.http_proxy = 'http://proxy:8080'
+            process.env.https_proxy = ''
+            const agent = utils.getWSProxyAgent(url)
+            should(agent).be.instanceOf(HttpProxyAgent)
+            agent.should.have.property('proxy')
+            agent.proxy.should.have.property('hostname', 'proxy')
+            agent.proxy.should.have.property('port', '8080')
+        })
+        it('should return a HttpsProxyAgent when https_proxy is set and the URL is wss://', function () {
+            const url = 'wss://test.com'
+            process.env.http_proxy = ''
+            process.env.https_proxy = 'http://proxy:8080'
+            const agent = utils.getWSProxyAgent(url)
+            should(agent).be.instanceOf(HttpsProxyAgent)
+            agent.should.have.property('proxy')
+            agent.proxy.should.have.property('hostname', 'proxy')
+            agent.proxy.should.have.property('port', '8080')
+        })
+        it('should set proxy options', function () {
+            const url = 'ws://test.com'
+            process.env.http_proxy = 'http://proxy:8080'
+            process.env.https_proxy = ''
+            const agent = utils.getWSProxyAgent(url, { timeout: 3210 })
+            agent.connectOpts.should.have.property('timeout', 3210)
+        })
+    })
+    describe('getHTTPProxyAgent', function () {
+        const HttpProxyAgent = require('http-proxy-agent').HttpProxyAgent
+        const HttpsProxyAgent = require('https-proxy-agent').HttpsProxyAgent
+
+        it('should return an agent object without any http or https proxy when env vars are not set', function () {
+            process.env.http_proxy = ''
+            process.env.https_proxy = ''
+            const agent = utils.getHTTPProxyAgent()
+            agent.should.not.have.property('http')
+            agent.should.not.have.property('https')
+        })
+        it('should return an agent object with http property when http_proxy is set', function () {
+            process.env.http_proxy = 'http://proxy:8080'
+            process.env.https_proxy = ''
+            const agent = utils.getHTTPProxyAgent()
+            agent.should.have.property('http').instanceOf(HttpProxyAgent)
+            agent.http.should.have.property('proxy')
+            agent.http.proxy.should.have.property('hostname', 'proxy')
+            agent.http.proxy.should.have.property('port', '8080')
+        })
+        it('should return an agent object with https property when https_proxy is set', function () {
+            process.env.http_proxy = ''
+            process.env.https_proxy = 'http://proxy:8080'
+            const agent = utils.getHTTPProxyAgent()
+            agent.should.have.property('https').instanceOf(HttpsProxyAgent)
+            agent.https.should.have.property('proxy')
+            agent.https.proxy.should.have.property('hostname', 'proxy')
+            agent.https.proxy.should.have.property('port', '8080')
+        })
+        it('should return an agent object with both http and https properties', function () {
+            process.env.http_proxy = 'http://proxy:8080'
+            process.env.https_proxy = 'http://proxy:8081'
+            const agent = utils.getHTTPProxyAgent()
+            agent.should.have.property('http').instanceOf(HttpProxyAgent)
+            agent.http.should.have.property('proxy')
+            agent.http.proxy.should.have.property('hostname', 'proxy')
+            agent.http.proxy.should.have.property('port', '8080')
+            agent.should.have.property('https').instanceOf(HttpsProxyAgent)
+            agent.https.should.have.property('proxy')
+            agent.https.proxy.should.have.property('hostname', 'proxy')
+            agent.https.proxy.should.have.property('port', '8081')
+        })
+        it('should set proxy options', function () {
+            process.env.http_proxy = 'http://proxy:8080'
+            process.env.https_proxy = 'http://proxy:8081'
+            const agent = utils.getHTTPProxyAgent({ timeout: 2345 })
+            agent.http.connectOpts.should.have.property('timeout', 2345)
+            agent.https.connectOpts.should.have.property('timeout', 2345)
+        })
+    })
 })

--- a/test/unit/lib/util_spec.js
+++ b/test/unit/lib/util_spec.js
@@ -103,59 +103,155 @@ describe('utils', function () {
             utils.compareNodeRedData({ modules: { 'node-red': 'latest' } }, { modules: undefined }).should.be.false()
         })
     })
+
     describe('getWSProxyAgent', function () {
         const HttpProxyAgent = require('http-proxy-agent').HttpProxyAgent
         const HttpsProxyAgent = require('https-proxy-agent').HttpsProxyAgent
-
-        it('should return null for no proxy', function () {
-            process.env.http_proxy = ''
-            process.env.https_proxy = ''
+        afterEach(function () {
+            delete process.env.http_proxy
+            delete process.env.https_proxy
+            delete process.env.no_proxy
+        })
+        it('should return null when there are no env vars set', function () {
+            delete process.env.http_proxy
+            delete process.env.https_proxy
+            delete process.env.no_proxy
             should(utils.getWSProxyAgent('ws://test.com')).be.null()
             should(utils.getWSProxyAgent('wss://test.com')).be.null()
         })
+        it('should not proxy any requests if they are excluded by no_local', function () {
+            process.env.http_proxy = 'http://proxy:3128'
+            process.env.https_proxy = 'http://proxy:3128'
+            process.env.no_proxy = 'test.com'
+            should(utils.getWSProxyAgent('ws://test.com')).be.null()
+            should(utils.getWSProxyAgent('wss://test.com')).be.null()
+            process.env.http_proxy = 'http://proxy:3128'
+            process.env.https_proxy = 'http://proxy:3128'
+            process.env.no_proxy = '192.168.0.100'
+            should(utils.getWSProxyAgent('ws://192.168.0.100')).be.null()
+            should(utils.getWSProxyAgent('wss://192.168.0.100')).be.null()
+        })
         it('should return a HttpProxyAgent when http_proxy is set and the URL is ws://', function () {
             const url = 'ws://test.com'
-            process.env.http_proxy = 'http://proxy:8080'
+            process.env.http_proxy = 'http://proxy:3128'
             process.env.https_proxy = ''
             const agent = utils.getWSProxyAgent(url)
             should(agent).be.instanceOf(HttpProxyAgent)
             agent.should.have.property('proxy')
             agent.proxy.should.have.property('hostname', 'proxy')
-            agent.proxy.should.have.property('port', '8080')
+            agent.proxy.should.have.property('port', '3128')
         })
         it('should return a HttpsProxyAgent when https_proxy is set and the URL is wss://', function () {
             const url = 'wss://test.com'
             process.env.http_proxy = ''
-            process.env.https_proxy = 'http://proxy:8080'
+            process.env.https_proxy = 'http://proxy:3128'
             const agent = utils.getWSProxyAgent(url)
             should(agent).be.instanceOf(HttpsProxyAgent)
             agent.should.have.property('proxy')
             agent.proxy.should.have.property('hostname', 'proxy')
-            agent.proxy.should.have.property('port', '8080')
+            agent.proxy.should.have.property('port', '3128')
         })
-        it('should set proxy options', function () {
+        it('should set http proxy options', function () {
             const url = 'ws://test.com'
             process.env.http_proxy = 'http://proxy:8080'
             process.env.https_proxy = ''
             const agent = utils.getWSProxyAgent(url, { timeout: 3210 })
             agent.connectOpts.should.have.property('timeout', 3210)
         })
+        it('should set https proxy options', function () {
+            const url = 'wss://test.com'
+            process.env.http_proxy = ''
+            process.env.https_proxy = 'https://proxy:8080'
+            const agent = utils.getWSProxyAgent(url, { timeout: 4444 })
+            agent.connectOpts.should.have.property('timeout', 4444)
+        })
     })
     describe('getHTTPProxyAgent', function () {
         const HttpProxyAgent = require('http-proxy-agent').HttpProxyAgent
         const HttpsProxyAgent = require('https-proxy-agent').HttpsProxyAgent
 
+        afterEach(function () {
+            delete process.env.http_proxy
+            delete process.env.https_proxy
+            delete process.env.no_proxy
+        })
+
         it('should return an agent object without any http or https proxy when env vars are not set', function () {
-            process.env.http_proxy = ''
+            delete process.env.http_proxy
+            delete process.env.https_proxy
+            delete process.env.no_proxy
+            const agent1 = utils.getHTTPProxyAgent('http://127.0.0.1')
+            agent1.should.not.have.property('http')
+            agent1.should.not.have.property('https')
+            const agent2 = utils.getHTTPProxyAgent('http://localhost:3000')
+            agent2.should.not.have.property('http')
+            agent2.should.not.have.property('https')
+            const agent3 = utils.getHTTPProxyAgent('http://testfuse.com')
+            agent3.should.not.have.property('http')
+            agent3.should.not.have.property('https')
+
+            const agent4 = utils.getHTTPProxyAgent('https://127.0.0.1')
+            agent4.should.not.have.property('http')
+            agent4.should.not.have.property('https')
+            const agent5 = utils.getHTTPProxyAgent('https://localhost:3000')
+            agent5.should.not.have.property('http')
+            agent5.should.not.have.property('https')
+            const agent6 = utils.getHTTPProxyAgent('https://testfuse.com')
+            agent6.should.not.have.property('http')
+            agent6.should.not.have.property('https')
+        })
+
+        it('should not proxy any requests if they are excluded by no_local', function () {
+            // http requests
+            process.env.http_proxy = 'http://proxy:8080'
+            process.env.https_proxy = 'http://proxy:8080'
+            process.env.no_proxy = 'testfuse.com,googoo.com,.parent-domain.org' // direct connection to testfuse.com, googoo.com, and any subdomain of parent-domain.org, otherwise use proxy
+            const agent1 = utils.getHTTPProxyAgent('http://testfuse.com:3000')
+            agent1.should.not.have.property('http')
+            agent1.should.not.have.property('https')
+            const agent2 = utils.getHTTPProxyAgent('http://googoo.com:3000')
+            agent2.should.not.have.property('http')
+            agent2.should.not.have.property('https')
+            const agent3 = utils.getHTTPProxyAgent('http://sub.parent-domain.org:3000')
+            agent3.should.not.have.property('http')
+            agent3.should.not.have.property('https')
+            const agent4 = utils.getHTTPProxyAgent('http://some-external.com')
+            agent4.should.have.property('http').instanceOf(HttpProxyAgent)
+            agent4.http.should.have.property('proxy')
+            agent4.http.proxy.should.have.property('hostname', 'proxy')
+            agent4.http.proxy.should.have.property('port', '8080')
+            // https requests
+            const agent5 = utils.getHTTPProxyAgent('https://testfuse.com:3000')
+            agent5.should.not.have.property('http')
+            agent5.should.not.have.property('https')
+            const agent6 = utils.getHTTPProxyAgent('https://googoo.com:3000')
+            agent6.should.not.have.property('http')
+            agent6.should.not.have.property('https')
+            const agent7 = utils.getHTTPProxyAgent('https://sub.parent-domain.org:3000')
+            agent7.should.not.have.property('http')
+            agent7.should.not.have.property('https')
+            const agent8 = utils.getHTTPProxyAgent('https://some-external.com')
+            agent8.should.have.property('https').instanceOf(HttpsProxyAgent)
+            agent8.https.should.have.property('proxy')
+            agent8.https.proxy.should.have.property('hostname', 'proxy')
+            agent8.https.proxy.should.have.property('port', '8080')
+        })
+
+        it('should return an agent object with http property when http_proxy is set and no_proxy is not in scope', function () {
+            process.env.http_proxy = 'http://proxy:8080'
             process.env.https_proxy = ''
-            const agent = utils.getHTTPProxyAgent()
-            agent.should.not.have.property('http')
-            agent.should.not.have.property('https')
+            process.env.no_proxy = 'random.com' // direct connection to random.com, otherwise use proxy
+            const agent = utils.getHTTPProxyAgent('http://testfuse.com:3000')
+            agent.should.have.property('http').instanceOf(HttpProxyAgent)
+            agent.http.should.have.property('proxy')
+            agent.http.proxy.should.have.property('hostname', 'proxy')
+            agent.http.proxy.should.have.property('port', '8080')
         })
         it('should return an agent object with http property when http_proxy is set', function () {
             process.env.http_proxy = 'http://proxy:8080'
             process.env.https_proxy = ''
-            const agent = utils.getHTTPProxyAgent()
+            process.env.no_proxy = 'random.com'
+            const agent = utils.getHTTPProxyAgent('http://127.0.0.1')
             agent.should.have.property('http').instanceOf(HttpProxyAgent)
             agent.http.should.have.property('proxy')
             agent.http.proxy.should.have.property('hostname', 'proxy')
@@ -164,30 +260,22 @@ describe('utils', function () {
         it('should return an agent object with https property when https_proxy is set', function () {
             process.env.http_proxy = ''
             process.env.https_proxy = 'http://proxy:8080'
-            const agent = utils.getHTTPProxyAgent()
+            const agent = utils.getHTTPProxyAgent('https://testfuse.com:3000')
             agent.should.have.property('https').instanceOf(HttpsProxyAgent)
             agent.https.should.have.property('proxy')
             agent.https.proxy.should.have.property('hostname', 'proxy')
             agent.https.proxy.should.have.property('port', '8080')
         })
-        it('should return an agent object with both http and https properties', function () {
+        it('should set http proxy options', function () {
             process.env.http_proxy = 'http://proxy:8080'
             process.env.https_proxy = 'http://proxy:8081'
-            const agent = utils.getHTTPProxyAgent()
-            agent.should.have.property('http').instanceOf(HttpProxyAgent)
-            agent.http.should.have.property('proxy')
-            agent.http.proxy.should.have.property('hostname', 'proxy')
-            agent.http.proxy.should.have.property('port', '8080')
-            agent.should.have.property('https').instanceOf(HttpsProxyAgent)
-            agent.https.should.have.property('proxy')
-            agent.https.proxy.should.have.property('hostname', 'proxy')
-            agent.https.proxy.should.have.property('port', '8081')
-        })
-        it('should set proxy options', function () {
-            process.env.http_proxy = 'http://proxy:8080'
-            process.env.https_proxy = 'http://proxy:8081'
-            const agent = utils.getHTTPProxyAgent({ timeout: 2345 })
+            const agent = utils.getHTTPProxyAgent('http://127.0.0.1:3000', { timeout: 2345 })
             agent.http.connectOpts.should.have.property('timeout', 2345)
+        })
+        it('should set https proxy options', function () {
+            process.env.http_proxy = 'http://proxy:8080'
+            process.env.https_proxy = 'http://proxy:8081'
+            const agent = utils.getHTTPProxyAgent('https://127.0.0.1:3000', { timeout: 2345 })
             agent.https.connectOpts.should.have.property('timeout', 2345)
         })
     })


### PR DESCRIPTION
closes #270

## Description

* Updates Device Agent to work behind a HTTP proxy
  * updates agent manager for device setup (bootstrapping)
  * updates library access plugin (for Node-RED access to FF library)
  * updates the auth part we add to settings.js
  * updates audit logger (post requests for audit logging)
  * updates MQTT and HTTP parts of Device Editor tunnel
  * Supports `no_proxy` and `all_proxy` (comes free with `proxy-from-env`) 
* Passes `*_proxy` env vars through to Node-RED env
* Adds dep `http-proxy-agent`, `https-proxy-agent`  & `proxy-from-env`

### Notes
* Updates package.json to include runtime dependencies
   *  `http-proxy-agent` & `https-proxy-agent`  - the most popular and supported agents by a long way, used for both HTTP and MQTT(ws)
   * `proxy-from-env` - this determined if a proxy should be applied by inspecting the process env vars. This is the same package that `proxy-agent` uses (`proxy-agent` is the parent mono repo of   `http-proxy-agent` & `https-proxy-agent` )
   * `eslint-plugin-no-only-tests`
* Updates package.json to include dev dependencies
   * `proxy` - for testing MQTT comms via a proxy
   * `rewire` - used in 2 places. `rewire` replaces `require` and permits access to unreachable internals for unit testing
      *  `auditLogger/index_spec.js` - `auditLogger` only returns a function and was impossible to access internal `got` object for unit testing.
      * `template-settings_spec.js` - `template-settings` only returns the final settings object and was impossible to access internal `got` object for unit testing.
* Updates eslint to enable `no-only-tests`
   * This was missing and I accidentally pushed with .only in test.

### Tests added

```
  Test the AgentManager
    ✔ Should not extend got with proxies if env vars are not set
    Proxy Support
      ✔ Calls GOT with no agent when env vars are not set
      ✔ Calls GOT with an http agent when env var is set (provisionDevice)
      ✔ Calls GOT with an https agent when env var is set (provisionDevice)
      ✔ Calls GOT with an http agent when env var is set (quickConnectDevice)
      ✔ Calls GOT with an https agent when env var is set (quickConnectDevice)
      ✔ Calls GOT with an http agent when env var is set (_getDeviceInfo)
      ✔ Calls GOT with an https agent when env var is set (_getDeviceInfo)

  auditLogger
    ✔ should send log message to the logging URL (100ms)
    ✔ should ignore comms events and any .get events (39ms)
    ✔ should ignore auth events except auth.log events (38ms)
    ✔ should remove username and level properties from the log message
    Proxy support
      ✔ should not have a proxy if env vars are not set
      ✔ should use HTTP proxy agent if http_proxy environment variable is set
      ✔ should use HTTPS proxy agent if https_proxy environment variable is set

  HTTP Comms
    Proxy Support
      ✔ Creates the HTTP Comms Client
      ✔ Extends GOT with http proxy when env var is set
      ✔ Extends GOT with https proxy when env var is set

  Launcher
    ✔ Creates a new launcher instance (107ms)
    Proxy Support
      ✔ Passes proxy env vars to child process when set (83ms)

  MQTT Comms
    Proxy Support
      ✔ MQTT Comms Client does not set a proxy agent if process env does not contain proxy settings
      ✔ MQTT Comms Client has a HttpProxyAgent for ws connection
      ✔ MQTT Comms Client has a HttpsProxyAgent for wss connection
      ✔ MQTT Comms Client can connect with proxy (516ms)
      ✔ MQTT command gets a response when proxy is set (572ms)

  FFTeamLibraryPlugin
    ✔ should throw an error if projectID and applicationID are missing
    ✔ should throw an error if libraryID is missing
    ✔ should throw an error if token is missing
    Proxy support
      ✔ should create an instance with valid configuration and no proxy
      ✔ should extend got to use http proxy when env var http_proxy is set
      ✔ should extend got to use https proxy when env var https_proxy is set
      ✔ should extend got to use http & https proxies when env vars are set

  template-settings
    ✔ should load default settings
    ✔ should call got.get with the correct parameters when verifying token
    ✔ should cache the token verification result for subsequent calls within 30 seconds
    - should not cache invalid token
    - should return without hitting cache or API if the token is not valid
    - should return null for the users function
    - should return null for the authenticate function
    - should set the https options if provided
    - should set the httpStatic option if provided
    Proxy Support
      ✔ should not extend got when env vars http(s)_proxy are not set
      ✔ should extend got to use http proxy when env var http_proxy is set (3180ms)
      ✔ should extend got to use https proxy when env var https_proxy is set (3134ms)

  utils
    getWSProxyAgent
      ✔ should return null when there are no env vars set
      ✔ should not proxy any requests if they are excluded by no_local
      ✔ should return a HttpProxyAgent when http_proxy is set and the URL is ws://
      ✔ should return a HttpsProxyAgent when https_proxy is set and the URL is wss://
      ✔ should set http proxy options
      ✔ should set https proxy options
    getHTTPProxyAgent
      ✔ should return an agent object without any http or https proxy when env vars are not set
      ✔ should not proxy any requests if they are excluded by no_local
      ✔ should return an agent object with http property when http_proxy is set and no_proxy is not in scope
      ✔ should return an agent object with http property when http_proxy is set
      ✔ should return an agent object with https property when https_proxy is set
      ✔ should set http proxy options
      ✔ should set https proxy options


  51 passing (8s)
  6 pending
```


## Related Issue(s)

#270 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

