### PR TITLE
Bump docker base to Node 18

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:18-alpine
 
 ARG VERSION=latest
 

--- a/docker/Dockerfile_flowforge
+++ b/docker/Dockerfile_flowforge
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:18-alpine
 
 ARG VERSION=latest
 


### PR DESCRIPTION
Update base images to Node 18 - not 20 due to the arm build issues. But this will get NR 4 running again on the device agent.