### PR TITLE
Add heartbeat to Editor WebSocket Tunnel

### DIFF
--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -248,6 +248,7 @@ class EditorTunnel {
                     })
                 }
             })
+            clearInterval(this.pingInterval)
             this.pingInterval = setInterval(() => {
                 debug('Sending WS editor tunnel ping')
                 socket.ping()

--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -248,6 +248,10 @@ class EditorTunnel {
                     })
                 }
             })
+            this.pingInterval = setInterval(() => {
+                debug('Sending WS editor tunnel ping')
+                socket.ping()
+            }, 15000)
         }
         socket.on('close', async (code, reason) => {
             if (Buffer.isBuffer(reason)) {
@@ -257,6 +261,7 @@ class EditorTunnel {
             info(`Editor tunnel closed code=${code} reason=${reason}`)
             socket.removeAllListeners()
             this.socket = null
+            clearInterval(this.pingInterval)
             clearTimeout(this.reconnectTimeout)
             // Pre 1.12, FF returned '1008/No Tunnel' - but 1008 was also used
             // for other scenarios, so we have to check both code and reason text.
@@ -310,6 +315,7 @@ class EditorTunnel {
         // ensure any active timers are stopped
         clearInterval(this.connectionReadyInterval)
         clearTimeout(this.reconnectTimeout)
+        clearInterval(this.pingInterval)
     }
 
     async waitForConnection () {

--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -252,7 +252,7 @@ class EditorTunnel {
             this.pingInterval = setInterval(() => {
                 debug('Sending WS editor tunnel ping')
                 socket.ping()
-            }, 15000)
+            }, 40000)
         }
         socket.on('close', async (code, reason) => {
             if (Buffer.isBuffer(reason)) {

--- a/lib/editor/tunnel.js
+++ b/lib/editor/tunnel.js
@@ -251,7 +251,9 @@ class EditorTunnel {
             clearInterval(this.pingInterval)
             this.pingInterval = setInterval(() => {
                 debug('Sending WS editor tunnel ping')
-                socket.ping()
+                try {
+                    socket.ping()
+                } catch (err) { }
             }, 40000)
         }
         socket.on('close', async (code, reason) => {


### PR DESCRIPTION
fixes #288

## Description

<!-- Describe your changes in detail -->
Sends a Websocket Ping every ~15~ 40 seconds to ensure the Editor Tunnel WebSocket stays open

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#288

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

