### PR TITLE
Add HOME env var to passed through list

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -429,6 +429,9 @@ class Launcher {
         // must always include the PATH so npm works
         env.PATH = process.env.PATH
 
+        // should set HOME env var
+        env.HOME = process.env.HOME
+
         // Use local timezone if set, else use one from snapshot settings
         // this will be ignored on Windows as it does not use the TZ env var
         env.TZ = process.env.TZ ? process.env.TZ : this.settings?.settings?.timeZone

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -430,7 +430,11 @@ class Launcher {
         env.PATH = process.env.PATH
 
         // should set HOME env var
-        env.HOME = process.env.HOME
+        if (process.platform === 'win32') {
+            env.UserProfile = process.env.UserProfile
+        } else {
+            env.HOME = process.env.HOME
+        }
 
         // Use local timezone if set, else use one from snapshot settings
         // this will be ignored on Windows as it does not use the TZ env var


### PR DESCRIPTION
fixes #298

## Description

<!-- Describe your changes in detail -->
Some nodes make user of the `HOME` env var (or `UserProfile` on windows) so need to make sure it's is set.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#298 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

