### PR TITLE
Allow arguments to device agent

### DIFF
--- a/service/flowfuse-device.service
+++ b/service/flowfuse-device.service
@@ -13,7 +13,7 @@ Group=pi
 WorkingDirectory=/opt/flowfuse-device
 
 Environment="NODE_OPTIONS=--max_old_space_size=512"
-ExecStart=/usr/bin/env flowfuse-device-agent
+ExecStart=/usr/bin/env -S flowfuse-device-agent
 # Use SIGINT to stop
 KillSignal=SIGINT
 # Auto restart on crash

--- a/service/raspbian-install-device-agent.sh
+++ b/service/raspbian-install-device-agent.sh
@@ -94,7 +94,7 @@ User=$USER
 WorkingDirectory=/opt/flowfuse-device
 
 Environment="NODE_OPTIONS=--max_old_space_size=512"
-ExecStart=/usr/bin/env flowfuse-device-agent
+ExecStart=/usr/bin/env -S flowfuse-device-agent
 # Use SIGINT to stop
 KillSignal=SIGINT
 # Auto restart on crash


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Allow cmd line args to be passed to the device agent when starting as a service

## Related Issue(s)

<!-- What issue does this PR relate to? -->
https://app-eu1.hubspot.com/help-desk/26586079/view/233410279/ticket/3796627166/thread/4423329272#comment

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

