### PR TITLE
Update flowfuse-device.service with Example for port

### DIFF
--- a/service/flowfuse-device.service
+++ b/service/flowfuse-device.service
@@ -13,6 +13,8 @@ Group=pi
 WorkingDirectory=/opt/flowfuse-device
 
 Environment="NODE_OPTIONS=--max_old_space_size=512"
+# If you need port specifications:
+# ExecStart=/usr/bin/env -S flowforge-device-agent -p 1881
 ExecStart=/usr/bin/env -S flowfuse-device-agent
 # Use SIGINT to stop
 KillSignal=SIGINT


### PR DESCRIPTION
## Description

Include an example with port configuration, or should we, by default, include it but for port 1880?


<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

