### PR TITLE
Ensure NODE_EXTRA_CA_CERTS is passed to NR

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -429,6 +429,11 @@ class Launcher {
         // must always include the PATH so npm works
         env.PATH = process.env.PATH
 
+        // pass through extra certs
+        if (process.env.NODE_EXTRA_CA_CERTS) {
+            env.NODE_EXTRA_CA_CERTS = process.env.NODE_EXTRA_CA_CERTS
+        }
+
         // should set HOME env var
         if (process.platform === 'win32') {
             env.UserProfile = process.env.UserProfile


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
This means NR instances (and the project nodes) will trust a internal Cert Authority if provided.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
Came up from a customer engagement

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

