### PR TITLE
Audit log crashes

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -5,6 +5,7 @@ const path = require('path')
 const { log, info, debug, warn, NRlog } = require('./logging/log')
 const { copyDir, hasProperty } = require('./utils')
 const { States } = require('./states')
+const { default: got } = require('got')
 
 const MIN_RESTART_TIME = 10000 // 10 seconds
 const MAX_RESTART_COUNT = 5
@@ -383,6 +384,31 @@ class Launcher {
         } catch (error) {
             info(`Could not write theme files to disk: '${targetDir}'`)
         }
+    }
+
+    async logAuditEvent (event, body) {
+        const data = {
+            timestamp: Date.now(),
+            event
+        }
+        if (body && typeof body === 'object') {
+            if (body.error) {
+                data.error = {
+                    code: body.error.code || 'unexpected_error',
+                    error: body.error.error || body.error.message || 'Unexpected error'
+                }
+            } else {
+                Object.assign(data, body)
+            }
+        }
+        return got.post(this.auditLogURL, {
+            json: data,
+            headers: {
+                authorization: 'Bearer ' + this.config.token
+            }
+        }).catch(_err => {
+            console.error('Failed to log audit event', _err, event)
+        })
     }
 
     async start () {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -554,6 +554,7 @@ class Launcher {
                         info('Node-RED restart loop detected - stopping')
                         this.state = States.CRASHED
                         restart = false
+                        await this.logAuditEvent('crashed', { info: { code: 'loop_detected', info: 'Node-RED restart loop detected' } })
                         await this.agent?.checkIn()
                     }
                 }


### PR DESCRIPTION
closes #309

## Description

* adds support for sending audit events from launcher (as nr-launcher does)
* utilises above to send "crashed" event


### tests:

```
  Launcher
    ✔ calls logAuditEvent when it crashes (84ms)
```

## Related Issue(s)

owner #309
parent https://github.com/FlowFuse/flowfuse/issues/4295

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

