### PR TITLE
Use port from config file

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,7 +207,10 @@ Please ensure the parent directory is writable, or set a different path with -d`
         return {
             AgentManager,
             webServer,
-            options
+            options: {
+                ...ConfigLoader.defaults,
+                ...options
+            }
         }
     }
     return null

--- a/lib/cli/args.js
+++ b/lib/cli/args.js
@@ -32,7 +32,6 @@ module.exports = [
         name: 'port',
         alias: 'p',
         type: Number,
-        defaultValue: 1880,
         typeLabel: '{underline number}',
         group: 'main'
     },
@@ -67,7 +66,6 @@ module.exports = [
         name: 'ui',
         description: 'Start the Web UI Server (optional, does not run by default)',
         type: Boolean,
-        defaultValue: false,
         alias: 'w',
         group: 'ui'
     },
@@ -75,14 +73,12 @@ module.exports = [
         name: 'ui-host',
         description: 'Web UI server host. Default: {underline (0.0.0.0)} (listen on all interfaces)',
         type: String,
-        defaultValue: '0.0.0.0',
         group: 'ui'
     },
     {
         name: 'ui-port',
         description: 'Web UI server port. Default: {underline 1879}',
         type: Number,
-        defaultValue: 1879,
         group: 'ui'
     },
     {

--- a/lib/config.js
+++ b/lib/config.js
@@ -137,9 +137,17 @@ function config (options) {
 
     const version = require('../package.json').version
 
+    const defaults = {
+        port: 1880,
+        ui: false,
+        'ui-host': '0.0.0.0',
+        'ui-port': 1879
+    }
+
     return {
         version,
-        ...options,
-        ...parsedOptions.deviceConfig
+        ...defaults,
+        ...parsedOptions.deviceConfig,
+        ...options
     }
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -139,7 +139,7 @@ function config (options) {
 
     return {
         version,
-        ...parsedOptions.deviceConfig,
-        ...options
+        ...options,
+        ...parsedOptions.deviceConfig
     }
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -14,10 +14,19 @@ const yaml = require('yaml')
  * @property {string} [deviceVersion] - The device version
  * @property {string} [deviceDescription] - The device description
 */
+
+const defaults = {
+    port: 1880,
+    ui: false,
+    uiHost: '0.0.0.0',
+    uiPort: 1879
+}
+
 module.exports = {
     parseDeviceConfigFile,
     parseDeviceConfig,
-    config
+    config,
+    defaults
 }
 
 /**
@@ -136,13 +145,6 @@ function config (options) {
     delete parsedOptions.config
 
     const version = require('../package.json').version
-
-    const defaults = {
-        port: 1880,
-        ui: false,
-        'ui-host': '0.0.0.0',
-        'ui-port': 1879
-    }
 
     return {
         version,


### PR DESCRIPTION
fixes #312

## Description

<!-- Describe your changes in detail -->
Default options overwrite port number in config file

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#312 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

