### PR TITLE
Randomise reconnect timing

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,0 +1,1 @@
+process.env.NODE_ENV = 'test'

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -9,6 +9,7 @@ const Launcher = require('./launcher.js')
 const { info, warn, debug } = require('./logging/log')
 const utils = require('./utils.js')
 const { States, isTargetState, isValidState } = require('./states')
+const MQTT_CONNECT_DELAY_MAX = process.env.NODE_ENV === 'test' ? 25 : 5000
 
 const PROJECT_FILE = 'flowforge-project.json'
 
@@ -137,7 +138,7 @@ class Agent {
                 // We have been provided a broker URL to use
                 this.mqttClient = mqttClient.newMQTTClient(this, this.config)
                 // Wait a short random delay to reduce stress on broker when large numbers of devices come on-line
-                await new Promise(_resolve => setTimeout(_resolve, randomInt(20, 5000)))
+                await new Promise(_resolve => setTimeout(_resolve, randomInt(20, MQTT_CONNECT_DELAY_MAX)))
                 this.mqttClient.start()
                 this.mqttClient.setApplication(this.currentApplication)
                 this.mqttClient.setProject(this.currentProject)

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -1,5 +1,6 @@
 const { IntervalJitter } = require('./IntervalJitter')
 const { existsSync } = require('fs')
+const { randomInt } = require('crypto')
 const fs = require('fs/promises')
 const path = require('path')
 const httpClient = require('./http')
@@ -135,6 +136,8 @@ class Agent {
                 }
                 // We have been provided a broker URL to use
                 this.mqttClient = mqttClient.newMQTTClient(this, this.config)
+                // Wait a short random delay to reduce stress on broker when large numbers of devices come on-line 
+                await new Promise(r => setTimeout(r, randomInt(20, 5000)));
                 this.mqttClient.start()
                 this.mqttClient.setApplication(this.currentApplication)
                 this.mqttClient.setProject(this.currentProject)

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -136,8 +136,8 @@ class Agent {
                 }
                 // We have been provided a broker URL to use
                 this.mqttClient = mqttClient.newMQTTClient(this, this.config)
-                // Wait a short random delay to reduce stress on broker when large numbers of devices come on-line 
-                await new Promise(r => setTimeout(r, randomInt(20, 5000)));
+                // Wait a short random delay to reduce stress on broker when large numbers of devices come on-line
+                await new Promise(_resolve => setTimeout(_resolve, randomInt(20, 5000)))
                 this.mqttClient.start()
                 this.mqttClient.setApplication(this.currentApplication)
                 this.mqttClient.setProject(this.currentProject)

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -4,6 +4,7 @@ const { IntervalJitter } = require('./IntervalJitter')
 const url = require('url')
 const EditorTunnel = require('./editor/tunnel')
 const { getWSProxyAgent } = require('./utils')
+const { randomInt } = require('crypto')
 
 class MQTTClient {
     /**
@@ -42,7 +43,7 @@ class MQTTClient {
             clientId: config.brokerUsername,
             username: config.brokerUsername,
             password: config.brokerPassword,
-            reconnectPeriod: 15000,
+            reconnectPeriod: randomInt(13000, 25000),
             queueQoSZero: false
         }
         setMQTT(this)


### PR DESCRIPTION
closes #314

## Description

To alleviate stresses on broker, a variation in the reconnect timing is introduced

The exact value may wish to be tweaked but I went with upto 2 seconds sooner and no more than 10s later than the original 15s fixed time

## Related Issue(s)

#314

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

