### PR TITLE
Add support for picking up `httpNodeAuth` from device yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Extra options   | Description
 `interval`      | How often, in seconds, the agent checks in with the platform. Default: 60s
 `intervalJitter`| How much, in seconds, to vary the heartbeat +/- `intervalJitter`. Default: 10s
 `moduleCache`   | If the device can not access npmjs.org then use the node modules cache in `module_cache` directory. Default `false`
+`httpNodeAuth`  | If set, the endpoints created in Node-RED flows will require this username and password to access them. Default: `false`
 
 
 #### Node-RED options

--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ Extra options   | Description
 `interval`      | How often, in seconds, the agent checks in with the platform. Default: 60s
 `intervalJitter`| How much, in seconds, to vary the heartbeat +/- `intervalJitter`. Default: 10s
 `moduleCache`   | If the device can not access npmjs.org then use the node modules cache in `module_cache` directory. Default `false`
-`httpNodeAuth`  | If set, the endpoints created in Node-RED flows will require this username and password to access them. Default: `false`
 
 
 #### Node-RED options
@@ -125,6 +124,7 @@ Node-RED options | Description
 `port`           | The port to listen on. Default: 1880
 `https`          | Enable HTTPS. See below for details
 `httpStatic`     | Enable serving of static content from a local path
+`httpNodeAuth`   | If set, any endpoints created in Node-RED flows will require this username and password to access them. Default: `false`
 
 ##### `https` configuration
 
@@ -164,6 +164,20 @@ httpStatic:
   - path: /opt/flowfuse-device/static-content/js
     root: /js
 ```
+
+##### `httpNodeAuth` configuration
+
+This option can be used to apply basic auth to HTTP endpoints created in Node-RED.
+This will also protect node-red-dashboard.
+Full details can be found in [HTTP Node security documentation](https://nodered.org/docs/user-guide/runtime/securing-node-red#http-node-security).
+
+Example:
+```yml
+httpStatic:
+   user: user
+   pass: $2a$08$zZWtXTja0fB1pzD4sHCMyOCMYz2Z6dNbM6tl8sJogENOMcxWV9DN.
+```
+
 
 ### `device.yml` - for provisioning
 

--- a/lib/AgentManager.js
+++ b/lib/AgentManager.js
@@ -19,7 +19,10 @@ class AgentManager {
         this.init({})
         /** @type {import('./agent.js').Agent} */
         this.agent = null
+        /** Device configuration processed from device yaml and options */
         this.configuration = null
+        /** The original device yaml data as JS object */
+        this.provisioningExtras = null
     }
 
     init = (options) => {
@@ -28,6 +31,7 @@ class AgentManager {
         this._state = 'unknown'
         this.agent = null
         this.configuration = null
+        this.provisioningExtras = null
         this.client = GOT.extend({})
         return this
     }
@@ -55,7 +59,11 @@ class AgentManager {
         if (!this.options) {
             throw new Error('Agent Manager not initialised')
         }
-        this.configuration = require('./config').config(this.options)
+        const config = require('./config').config(this.options)
+        // separate out the provisioningExtras object. everything else goes into configuration
+        const { provisioningExtras, ...configuration } = config
+        this.configuration = configuration
+        this.provisioningExtras = provisioningExtras
         initLogger(this.configuration)
     }
 
@@ -408,11 +416,11 @@ class AgentManager {
         return result
     }
 
-    async _provisionDevice (device) {
-        const credentials = device.credentials
-        const forgeURL = device.forgeURL
-        const deviceId = device.id
-        const deviceJS = {
+    async _provisionDevice (platformProvisioningData) {
+        const credentials = platformProvisioningData.credentials
+        const forgeURL = platformProvisioningData.forgeURL
+        const deviceId = platformProvisioningData.id
+        const deviceJSPriority = {
             deviceId,
             forgeURL,
             token: credentials.token,
@@ -422,6 +430,10 @@ class AgentManager {
             brokerPassword: credentials.broker?.password,
             autoProvisioned: true
         }
+
+        // Generate deviceJs from ...this.provisioningExtras (extra config from the provisioning yaml) and the priority deviceJs
+        const deviceJS = { ...this.provisioningExtras, ...deviceJSPriority }
+
         if (this.options?.otc) {
             // when _provisionDevice is called, it was either cli-setup or auto-provisioned
             // not both! delete the other flag

--- a/lib/config.js
+++ b/lib/config.js
@@ -13,6 +13,12 @@ const yaml = require('yaml')
  * @property {string} [deviceType] - The device type
  * @property {string} [deviceVersion] - The device version
  * @property {string} [deviceDescription] - The device description
+ * @property {string} [brokerURL] - The broker URL
+ * @property {string} [brokerUsername] - The broker username
+ * @property {string} [brokerPassword] - The broker password
+ * @property {object} [httpNodeAuth] - The HTTP node auth
+ * @property {string} [httpNodeAuth.user] - The HTTP node auth user
+ * @property {string} [httpNodeAuth.pass] - The HTTP node auth password
 */
 
 const defaults = {

--- a/lib/config.js
+++ b/lib/config.js
@@ -117,6 +117,19 @@ function parseDeviceConfig (deviceConfig) {
         }
     }
 
+    if (deviceConfig.httpNodeAuth) {
+        if (!deviceConfig.httpNodeAuth.user) {
+            missing.push('httpNodeAuth.user')
+        } else if (!deviceConfig.httpNodeAuth.pass) {
+            missing.push('httpNodeAuth.pass')
+        } else {
+            localConfig.httpNodeAuth = {
+                user: deviceConfig.httpNodeAuth.user,
+                pass: deviceConfig.httpNodeAuth.pass
+            }
+        }
+    }
+
     if (missing.length > 0) {
         const missingList = missing.map(v => ` - ${v}`).join('\n')
         result.message = `Config file missing required options:\n${missingList}`

--- a/lib/config.js
+++ b/lib/config.js
@@ -165,10 +165,24 @@ function config (options) {
 
     const version = require('../package.json').version
 
-    return {
+    const result = {
         version,
         ...defaults,
         ...parsedOptions.deviceConfig,
         ...options
     }
+
+    if (parsedOptions.deviceConfig.provisioningMode) {
+        let provisioningExtras = null
+        provisioningExtras = {
+            ...parsedOptions.deviceConfig
+        }
+        const excludeProps = ['provisioningMode', 'provisioningName', 'provisioningTeam', 'provisioningToken', 'token', 'forgeURL', 'deviceId', 'credentialSecret', 'deviceFile', 'brokerURL', 'brokerUsername', 'brokerPassword', 'autoProvisioned', 'cliSetup']
+        for (const prop of excludeProps) {
+            delete provisioningExtras[prop]
+        }
+        result.provisioningExtras = provisioningExtras
+    }
+
+    return result
 }

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -298,6 +298,12 @@ class Launcher {
             // The `httpStatic` config is passed straight through to Node-RED
             settings.httpStatic = this.config.httpStatic
         }
+        if (this.config.httpNodeAuth) {
+            // The `httpNodeAuth` config is passed straight through to Node-RED
+            // It is however sanitised in config.js to ensure it is an object
+            // containing `user` and `pass` properties.
+            settings.httpNodeAuth = this.config.httpNodeAuth
+        }
         await fs.writeFile(this.files.userSettings, JSON.stringify(settings))
     }
 

--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -109,6 +109,7 @@ const runtimeSettings = {
     uiPort: settings.port,
     adminAuth: auth,
     httpAdminRoot: 'device-editor',
+    httpNodeAuth: false,
     disableEditor: false, // permit editing of device flows as of FF v1.7.0
     httpNodeCors: { origin: '*', methods: 'GET,PUT,POST,DELETE' },
     externalModules: {
@@ -195,5 +196,12 @@ if (settings.https) {
 
 if (settings.httpStatic) {
     runtimeSettings.httpStatic = settings.httpStatic
+}
+
+if (settings.httpNodeAuth && typeof settings.httpNodeAuth === 'object') {
+    runtimeSettings.httpNodeAuth = {
+        user: settings.httpNodeAuth.user,
+        pass: settings.httpNodeAuth.pass
+    }
 }
 module.exports = runtimeSettings

--- a/test/unit/lib/config_spec.js
+++ b/test/unit/lib/config_spec.js
@@ -1,0 +1,200 @@
+const mocha = require('mocha') // eslint-disable-line
+const should = require('should')
+const sinon = require('sinon')
+const { config, parseDeviceConfig, parseDeviceConfigFile } = require('../../../lib/config')
+const fs = require('fs/promises')
+const path = require('path')
+const os = require('os')
+const yaml = require('yaml')
+
+describe('config loader', () => {
+    /** @type {sinon.SinonSandbox} */
+    let sandbox
+    let configFilePath
+    let projectPath
+    const deviceConfig = {
+        forgeURL: 'https://forge.flowfuse.io',
+        credentialSecret: 'secret',
+        port: 1880,
+        deviceId: 'DEVICEID',
+        token: 'TOKEN',
+        dir: '',
+        verbose: true
+    }
+    function generateYaml (_config) {
+        _config = Object.assign({}, deviceConfig, _config)
+        return yaml.stringify(_config)
+    }
+    async function generateYamlFile (_config) {
+        const ymlData = generateYaml(_config)
+        await fs.writeFile(configFilePath, ymlData)
+        return configFilePath
+    }
+
+    beforeEach(async function () {
+        sandbox = sinon.createSandbox()
+        // shush the console
+        sandbox.stub(console, 'log')
+        deviceConfig.dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ff-launcher-'))
+        configFilePath = path.join(deviceConfig.dir, 'device.yml')
+        projectPath = path.join(deviceConfig.dir, 'project')
+        await fs.mkdir(projectPath)
+        // since we will be loading the generated template+settings, we need to simlink the
+        // node_modules to the project directory (so it can pick up ant requires in the settings.js file)
+        await fs.symlink(path.join(__dirname, '..', '..', '..', 'node_modules'), path.join(projectPath, 'node_modules'), 'dir')
+    })
+
+    afterEach(async function () {
+        sandbox.restore()
+        try {
+            await fs.rm(deviceConfig.dir, { recursive: true, force: true })
+        } catch (_error) {
+        }
+    })
+
+    describe('parseDeviceConfig', () => {
+        it('should parse a valid device config', async function () {
+            const ymlData = await generateYaml()
+            const result = parseDeviceConfig(ymlData)
+            should.exist(result)
+            result.should.have.a.property('valid', true)
+            result.should.have.a.property('deviceConfig').and.be.an.Object()
+
+            const parsed = result.deviceConfig
+            parsed.should.have.a.property('forgeURL', 'https://forge.flowfuse.io')
+            parsed.should.have.a.property('forgeURL', 'https://forge.flowfuse.io')
+            parsed.should.have.a.property('credentialSecret', 'secret')
+            parsed.should.have.a.property('port', 1880)
+            parsed.should.have.a.property('deviceId', 'DEVICEID')
+            parsed.should.have.a.property('token', 'TOKEN')
+            parsed.should.have.a.property('dir', deviceConfig.dir)
+            parsed.should.have.a.property('verbose', true)
+            parsed.should.not.have.a.property('httpNodeAuth')
+        })
+        describe('httpNodeAuth', () => {
+            it('should parse config with httpNodeAuth set false', async function () {
+                const extraSettings = {
+                    httpNodeAuth: false
+                }
+                const ymlData = await generateYaml(extraSettings)
+                const result = parseDeviceConfig(ymlData)
+                should.exist(result)
+                result.should.have.a.property('valid', true)
+                result.should.have.a.property('deviceConfig').and.be.an.Object()
+
+                const parsed = result.deviceConfig
+                parsed.should.have.a.property('httpNodeAuth', false)
+            })
+            it('should parse config with valid httpNodeAuth settings', async function () {
+                const extraSettings = {
+                    httpNodeAuth: {
+                        user: 'user',
+                        pass: 'pass'
+                    }
+                }
+                const ymlData = await generateYaml(extraSettings)
+                const result = parseDeviceConfig(ymlData)
+                should.exist(result)
+                result.should.have.a.property('valid', true)
+                result.should.have.a.property('deviceConfig').and.be.an.Object()
+
+                const parsed = result.deviceConfig
+                parsed.should.have.a.property('httpNodeAuth').and.be.an.Object()
+                parsed.httpNodeAuth.should.have.a.property('user', 'user')
+                parsed.httpNodeAuth.should.have.a.property('pass', 'pass')
+            })
+            it('should not validate invalid httpNodeAuth (string)', async function () {
+                const extraSettings = {
+                    httpNodeAuth: 'invalid'
+                }
+                const ymlData = await generateYaml(extraSettings)
+                const parsed = parseDeviceConfig(ymlData)
+                should.exist(parsed)
+                parsed.should.have.a.property('valid', false)
+                // parsed.should.have.a.property('message').and.match(/missing required options.httpNodeAuth\.user*/s)
+                parsed.should.have.a.property('message').and.be.a.String()
+                parsed.message.should.match(/missing required options.*httpNodeAuth\.user*/s)
+            })
+            it('should not validate invalid httpNodeAuth (missing pass)', async function () {
+                const extraSettings = {
+                    httpNodeAuth: {
+                        user: 'user'
+                    }
+                }
+                const ymlData = await generateYaml(extraSettings)
+                const parsed = parseDeviceConfig(ymlData)
+                should.exist(parsed)
+                parsed.should.have.a.property('valid', false)
+                parsed.should.have.a.property('message').and.be.a.String()
+                parsed.message.should.match(/missing required options.*httpNodeAuth\.pass*/s)
+            })
+        })
+    })
+
+    describe('parseDeviceConfigFile', () => {
+        it('should load and parse a valid device config file', async function () {
+            await generateYamlFile()
+
+            const result = parseDeviceConfigFile(configFilePath)
+            should.exist(result)
+            result.should.have.a.property('valid', true)
+            result.should.have.a.property('deviceConfig').and.be.an.Object()
+
+            const parsed = result.deviceConfig
+            parsed.should.have.a.property('forgeURL', 'https://forge.flowfuse.io')
+            parsed.should.have.a.property('credentialSecret', 'secret')
+            parsed.should.have.a.property('port', 1880)
+            parsed.should.have.a.property('deviceId', 'DEVICEID')
+            parsed.should.have.a.property('token', 'TOKEN')
+            parsed.should.have.a.property('dir', deviceConfig.dir)
+            parsed.should.have.a.property('verbose', true)
+            parsed.should.not.have.a.property('httpNodeAuth')
+        })
+    })
+
+    describe('config', () => {
+        it('should return a valid config', async function () {
+            await generateYamlFile()
+
+            const options = {
+                deviceFile: configFilePath,
+                config: 'blah blah', // should get returned as is
+                dummy: 'dummy' // extra options should get returned as is
+            }
+
+            const result = await config(options)
+            should.exist(result)
+            result.should.have.a.property('version').and.match(/^\d+\.\d+\.\d+$/)
+            result.should.have.a.property('port', 1880)
+            result.should.have.a.property('ui', false)
+            result.should.have.a.property('uiHost')
+            result.should.have.a.property('uiPort')
+            result.should.have.a.property('provisioningMode', false)
+            result.should.have.a.property('token', 'TOKEN')
+            result.should.have.a.property('forgeURL', 'https://forge.flowfuse.io')
+            result.should.have.a.property('deviceId', 'DEVICEID')
+            result.should.have.a.property('credentialSecret', 'secret')
+            result.should.have.a.property('dir', deviceConfig.dir)
+            result.should.have.a.property('verbose', true)
+            result.should.have.a.property('deviceFile', configFilePath)
+            result.should.have.a.property('config', 'blah blah')
+            result.should.have.a.property('dummy', 'dummy')
+        })
+        it('should throw for missing config file', async function () {
+            await generateYamlFile()
+
+            const options = {
+                deviceFile: configFilePath + '-i-do-not-exist'
+            }
+            should.throws(() => config(options), /ENOENT/)
+        })
+        it('should throw for bad config file', async function () {
+            await generateYamlFile({ httpNodeAuth: true }) // true is not a valid httpNodeAuth
+
+            const options = {
+                deviceFile: configFilePath
+            }
+            should.throws(() => config(options), /missing required options/)
+        })
+    })
+})

--- a/test/unit/lib/template-settings_spec.js
+++ b/test/unit/lib/template-settings_spec.js
@@ -116,6 +116,8 @@ describe('template-settings', () => {
         settings.logging.console.should.have.a.property('audit', false)
         settings.logging.console.should.have.a.property('handler').and.be.a.Function()
         settings.should.have.a.property('nodesDir', null)
+
+        settings.should.have.a.property('httpNodeAuth', false) // by default, this is false
     })
 
     it('should call got.get with the correct parameters when verifying token', async function () {
@@ -183,6 +185,21 @@ describe('template-settings', () => {
 
     it.skip('should set the httpStatic option if provided', async function () {
         // TODO: Implement test
+    })
+
+    it('should set the httpNodeAuth option if provided', async function () {
+        const extraConfig = {
+            httpNodeAuth: {
+                user: 'test',
+                pass: '$123456789'
+            }
+        }
+        const settingsFile = await generateSettingsFile(extraConfig)
+        const settings = require(settingsFile)
+        should.exist(settings)
+        settings.should.have.a.property('httpNodeAuth').and.be.an.Object()
+        settings.httpNodeAuth.should.have.a.property('user', 'test')
+        settings.httpNodeAuth.should.have.a.property('pass', '$123456789')
     })
 
     describe('Proxy Support', function () {


### PR DESCRIPTION
closes #317 
closes https://github.com/FlowFuse/flowfuse/issues/4185

## Description

* Updated config loader to pick up `httpNodeAuth` from the device yaml file
* Updates existing unit tests to ensure propery is passed through to template
* Adds missing config loader unit tests 
   *  Ensures config loader handles valid/invalid values for  `httpNodeAuth`
* Addresses carrying over values entered in the provisioning yaml to the final device yaml
   * satisfies the requirement of this task and https://github.com/FlowFuse/flowfuse/issues/4185
   * suitable unit tests added for this too

### Unit tests updated/added `test/unit/lib/template-settings_spec.js`
```
  template-settings
    ✔ should load default settings
    ✔ should set the httpNodeAuth option if provided
```


### New Unit tests file `test/unit/lib/AgentManager_spec.js`
```
  Test the AgentManager
    ✔ Agent Manager should request config from FlowFuse when started in provisioning mode
```

### New Unit tests file `test/unit/lib/config_spec.js`
```
  config loader
    parseDeviceConfig
      ✔ should parse a valid device config
      httpNodeAuth
        ✔ should parse config with httpNodeAuth set false
        ✔ should parse config with valid httpNodeAuth settings
        ✔ should not validate invalid httpNodeAuth (string)
        ✔ should not validate invalid httpNodeAuth (missing pass)
    parseDeviceConfigFile
      ✔ should load and parse a valid device config file
    config
      ✔ should return a valid runtime config
      ✔ should return a valid provisioning config and any extras
      ✔ should throw for missing config file
      ✔ should throw for bad config file
```


## Related Issue(s)

#317 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

