### PR TITLE
Pass through teamBroker feature flag to project nodes

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -195,7 +195,8 @@ class Launcher {
                     url: enabled ? this.config.brokerURL : '',
                     username: enabled ? this.config.brokerUsername : '',
                     password: enabled ? this.config.brokerPassword : ''
-                }
+                },
+                teamBrokerEnabled: enabled && !!this.settings?.features?.teamBroker
             }
         }
 


### PR DESCRIPTION
Part of https://github.com/FlowFuse/nr-project-nodes/issues/114

## Description

Passes through the `teamBroker` feature flag to the device settings so the Project Nodes know to offer the Team Broker options.

The flag is passed to the launcher via the changes in https://github.com/FlowFuse/flowfuse/pull/4789
