### PR TITLE
Apply custom message in login dialog on direct access

### DIFF
--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -42,7 +42,6 @@ let got
 let agentApplied
 
 const auth = {
-    type: 'credentials', // the type of the auth
     tokenHeader: 'x-access-token', // the header where node-red expects to find the token
     tokens: async function (token) {
         const [prefix, deviceId] = (token + '').split('_')
@@ -94,12 +93,6 @@ const auth = {
         } catch (err) {
             console.log('error getting new token', err)
         }
-    },
-    users: async function (username) {
-        return null
-    },
-    authenticate: async function (username, password) {
-        return null
     }
 }
 
@@ -168,6 +161,15 @@ const runtimeSettings = {
     nodesDir: settings.nodesDir || null,
     [themeName]: { ...themeSettings },
     editorTheme: { ...editorTheme }
+}
+runtimeSettings.editorTheme.login = {
+    message: 'Access to the editor is managed through the FlowFuse platform'
+}
+if (themeSettings.projectURL) {
+    runtimeSettings.editorTheme.login.button = {
+        url: themeSettings.projectURL,
+        label: 'Open FlowFuse Dashbaord'
+    }
 }
 
 if (settings.flowforge.auditLogger?.bin && settings.flowforge.auditLogger?.url) {

--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -163,7 +163,7 @@ const runtimeSettings = {
     editorTheme: { ...editorTheme }
 }
 runtimeSettings.editorTheme.login = {
-    message: 'Access to the editor is managed through the FlowFuse platform'
+    message: 'Access the editor through the FlowFuse platform'
 }
 if (themeSettings.projectURL) {
     runtimeSettings.editorTheme.login.button = {

--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -168,7 +168,7 @@ runtimeSettings.editorTheme.login = {
 if (themeSettings.projectURL) {
     runtimeSettings.editorTheme.login.button = {
         url: themeSettings.projectURL,
-        label: 'Open FlowFuse Dashbaord'
+        label: 'Open FlowFuse Dashboard'
     }
 }
 

--- a/test/unit/lib/template-settings_spec.js
+++ b/test/unit/lib/template-settings_spec.js
@@ -55,10 +55,7 @@ describe('template-settings', () => {
         const settings = require(settingsFile)
         should.exist(settings)
         settings.should.have.a.property('adminAuth').and.be.an.Object()
-        settings.adminAuth.should.have.a.property('type', 'credentials')
-        settings.adminAuth.should.have.a.property('users').and.be.a.Function()
-        settings.adminAuth.should.have.a.property('authenticate').and.be.a.Function()
-        settings.adminAuth.should.have.a.property('tokens').and.be.a.Function()
+        settings.adminAuth.should.not.have.a.property('type')
 
         settings.should.have.a.property('contextStorage').and.be.an.Object()
         settings.contextStorage.should.have.a.property('default', 'memory')
@@ -76,6 +73,9 @@ describe('template-settings', () => {
         settings.editorTheme.codeEditor.should.have.a.property('lib', 'monaco')
         settings.editorTheme.tours.should.be.false()
         settings.editorTheme.should.have.a.property('palette').and.be.an.Object()
+        settings.editorTheme.should.have.a.property('login').and.be.an.Object()
+        settings.editorTheme.login.should.have.a.property('message').and.be.an.String()
+        settings.editorTheme.login.should.have.a.property('button').and.be.an.Object()
 
         settings.should.have.a.property('externalModules').and.be.an.Object()
         settings.externalModules.should.have.a.property('autoInstall', true)


### PR DESCRIPTION
Fixes https://github.com/FlowFuse/node-red/issues/25

This PR removes the username/password fields from the login dialog when the editor is accessed directly. We get support requests asking what credentials to use - however we only support accessing the editor via the device agent proxy.

With NR 4.0.6 (to be released imminently), I've added the ability to insert a custom message/button on the login dialog when in this state. Older versions of NR will show a blank dialog.

<img width="673" alt="image" src="https://github.com/user-attachments/assets/e8e2e06a-56c7-4d9d-8c10-88aee20e20b5" />

Note: spotted the `dashbaord` typo when I took this screenshot for the PR... it will be fixed momentarily.