### PR TITLE
Better error logging when provisioning devices with token

### DIFF
--- a/lib/AgentManager.js
+++ b/lib/AgentManager.js
@@ -189,9 +189,9 @@ class AgentManager {
             }
 
             // Get the local IP address / MAC / Hostname of the device for use in naming
-            const { host, ip, mac, forgeOk } = await this._getDeviceInfo(provisioningConfig.forgeURL, this.configuration?.token)
+            const { host, ip, mac, forgeOk, _error } = await this._getDeviceInfo(provisioningConfig.forgeURL, this.configuration?.token)
             if (!forgeOk) {
-                throw new Error('Unable to connect to the Forge Platform')
+                throw new Error('Unable to connect to the Forge Platform', { cause: _error})
             }
             const type = 'Auto Provisioned' + (provisioningConfig.provisioningName ? ` [${provisioningConfig.provisioningName}]` : '')
             const team = provisioningConfig.provisioningTeam

--- a/lib/AgentManager.js
+++ b/lib/AgentManager.js
@@ -216,7 +216,7 @@ class AgentManager {
             provisioningOK = true
         } catch (err) {
             warn(`Problem encountered during provisioning: ${err.toString()}`)
-            warn(`Reason: ${err.response?.body || err.cause?.toString() ||'unknown'}`)
+            warn(`Reason: ${err.response?.body || err.cause?.toString() || 'unknown'}`)
             provisioningOK = false
         }
 

--- a/lib/AgentManager.js
+++ b/lib/AgentManager.js
@@ -216,7 +216,7 @@ class AgentManager {
             provisioningOK = true
         } catch (err) {
             warn(`Problem encountered during provisioning: ${err.toString()}`)
-            warn(`Reason: ${err.response?.body || 'unknown'}`)
+            warn(`Reason: ${err.response?.body || err.cause?.toString() ||'unknown'}`)
             provisioningOK = false
         }
 

--- a/lib/AgentManager.js
+++ b/lib/AgentManager.js
@@ -191,7 +191,7 @@ class AgentManager {
             // Get the local IP address / MAC / Hostname of the device for use in naming
             const { host, ip, mac, forgeOk, _error } = await this._getDeviceInfo(provisioningConfig.forgeURL, this.configuration?.token)
             if (!forgeOk) {
-                throw new Error('Unable to connect to the Forge Platform', { cause: _error})
+                throw new Error('Unable to connect to the Forge Platform', { cause: _error })
             }
             const type = 'Auto Provisioned' + (provisioningConfig.provisioningName ? ` [${provisioningConfig.provisioningName}]` : '')
             const team = provisioningConfig.provisioningTeam


### PR DESCRIPTION
fixes #337 

## Description

<!-- Describe your changes in detail -->
Errors from the `_getDeviceInfo` API call were being swallowed

This attaches them to the new Error being thrown so they can be shown

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#337 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

