### PR TITLE
Reload device settings when restarting in dev mode

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -185,7 +185,7 @@ class Agent {
             this.launcher = undefined
         }
         await this.updateTargetState(States.RUNNING)
-        await this.setState({ targetState: States.RUNNING })
+        await this.setState({ targetState: States.RUNNING, reloadSettings: true })
         return this.targetState === States.RUNNING
     }
 
@@ -660,6 +660,9 @@ class Agent {
                         }
                         this.oneTimeAssistantCheck = true
                     }
+                } else if (developerMode === true) {
+                    // We are in developerMode and have been asked to reload settings
+                    updateSettings = !!newState.reloadSettings
                 }
                 if (!skipToUpdate && !updateSnapshot && !updateSettings) {
                     // Nothing to update. So long as the target state is not SUSPENDED,

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -82,14 +82,22 @@ class MQTTClient {
             try {
                 const msg = JSON.parse(_message)
                 if (msg.command === 'update') {
+                    let refreshSettings = false
                     if (!this.sentInitialCheckin) {
                         // We haven't sent the initial checkin, but we've received
                         // an update; no need to resend the checkin
+                        refreshSettings = true
                         this.sentInitialCheckin = true
                     }
                     if (this.initialCheckinTimeout) {
+                        refreshSettings = true
                         clearTimeout(this.initialCheckinTimeout)
                         this.initialCheckinTimeout = null
+                    }
+                    if (refreshSettings && msg.mode === 'developer') {
+                        // If this is the first checkin response, and we're in developer mode,
+                        // trigger a reload of settings to ensure any updates are picked up
+                        msg.reloadSettings = true
                     }
                     await this.agent.setState(msg)
                 } else if (msg.command === 'startLog') {

--- a/lib/plugins/node_modules/@flowfuse/flowfuse-auth/httpAuthMiddleware.js
+++ b/lib/plugins/node_modules/@flowfuse/flowfuse-auth/httpAuthMiddleware.js
@@ -14,7 +14,6 @@ let httpNodeApp
 module.exports = {
     init (_options) {
         options = _options
-        console.log('init with options', options)
         return [
             async (req, res, next) => {
                 try {


### PR DESCRIPTION
Closes https://github.com/FlowFuse/flowfuse/issues/5069

When in developer mode, if the user triggers a restart via the UI, or if starting up the agent from scratch, trigger a reload of settings from the platform.

This ensures that any env vars/settings changes get picked up in an expected way. Previously this would require taking the device out of developer mode - which then resets the flows etc.