### PR TITLE
Remove custom callback resolve function

### DIFF
--- a/lib/plugins/node_modules/@flowfuse/flowfuse-auth/httpAuthMiddleware.js
+++ b/lib/plugins/node_modules/@flowfuse/flowfuse-auth/httpAuthMiddleware.js
@@ -52,7 +52,6 @@ module.exports = {
                     //         next(error)
                     //     }
                     } else {
-                        console.log('auth required - but we have options')
                         req.session.redirectTo = req.originalUrl
                         passport.authenticate('FlowFuse', { session: false })(req, res, next)
                     }

--- a/lib/plugins/node_modules/@flowfuse/flowfuse-auth/strategy.js
+++ b/lib/plugins/node_modules/@flowfuse/flowfuse-auth/strategy.js
@@ -14,34 +14,16 @@ function Strategy (options, verify) {
 util.inherits(Strategy, OAuth2Strategy)
 
 /**
- * Patch the authenticate function so we can do per-request generation of the
- * callback uri
+ * KEY DIFFERENCE BETWEEN Instance and Device versions of this:
+ *  - for Instances, we patch the authenticate function so we can do per-request generation of the
+ *    callback uri to get the http/https choice correct. This is because when running inside
+ *    k8s, internal requests may be http, but need to be considered as https when generating the
+ *    external callback url
+ *  - for Devices, we don't need to do that - so the code is gone.
+ * 
+ * IF we attempt to DRY the auth handler between device and launcher, this difference
+ * MUST be considered 
  */
-Strategy.prototype.__authenticate = Strategy.prototype.authenticate
-
-Strategy.prototype.authenticate = function (req, options) {
-    const strategyOptions = { ...options }
-
-    if (this.isRelativeCallback) {
-        // Get the base url of the request
-
-        // This logic comes from passport_oauth2/lib/utils - but we use our
-        // own check for whether to redirect to https or http based on the
-        // authorizationURL we've been provided
-        const app = req.app
-        let trustProxy = this._trustProxy
-        if (app && app.get && app.get('trust proxy')) {
-            trustProxy = true
-        }
-        const protocol = this.isSecure ? 'https' : 'http'
-        const host = (trustProxy && req.headers['x-forwarded-host']) || req.headers.host
-        const path = req.url || ''
-        const base = protocol + '://' + host + path
-        strategyOptions.callbackURL = (new url.URL(this.options.callbackURL, base)).toString()
-    }
-
-    return this.__authenticate(req, strategyOptions)
-}
 
 Strategy.prototype.userProfile = function (accessToken, done) {
     this._oauth2.useAuthorizationHeaderforGET(true)


### PR DESCRIPTION
## Description

The auth plugin, copied over from nr-launcher, included a custom resolving to turn the callbackURI into a fully qualified URL - including protocol.

For nr-launcher, this was needed due to the way https is terminated outside the platform.

But for devices, we don't need this custom behaviour and should fall back to the tried and tested built-in resolver provided by passport.

Tested and verified on production and localfs (non-https) setup.