### PR TITLE
Do not copy theme into project node_modules

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -80,6 +80,11 @@ class Launcher {
                 packageData.dependencies['@flowfuse/nr-assistant'] = `file:${devPath}`
             }
         }
+        if (!packageData.dependencies['@flowfuse/nr-theme']) {
+            // Ensure the theme package is in package.json so that its resources
+            // don't get removed by npm.
+            packageData.dependencies['@flowfuse/nr-theme'] = '*'
+        }
         packageData.version = `0.0.0-${this.snapshot.id}`
         packageData.name = this.snapshot.env.FF_PROJECT_NAME
         if (this.snapshot.name && this.snapshot.description) {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -239,7 +239,13 @@ class Launcher {
                 },
                 projectLink,
                 assistant
-            }
+            },
+            nodesDir: [
+                // This path exists when running the agent as a git clone
+                path.resolve(path.join(__dirname, '..', 'node_modules', '@flowfuse', 'nr-theme')),
+                // This path exists when running the agent as an npm installed package
+                path.resolve(path.join(__dirname, '..', '..', 'nr-theme'))
+            ]
         }
 
         // if licensed, add palette catalogues
@@ -258,9 +264,8 @@ class Launcher {
         // if licensed, add shared library config
         const libraryEnabled = this.settings?.features ? this.settings.features['shared-library'] : false
         if (libraryEnabled && this.config.licensed) {
-            settings.nodesDir = [
-                path.join(__dirname, 'plugins', 'node_modules', '@flowforge', 'flowforge-library-plugin')
-            ]
+            settings.nodesDir = settings.nodesDir || []
+            settings.nodesDir.push(path.join(__dirname, 'plugins', 'node_modules', '@flowforge', 'flowforge-library-plugin'))
             const sharedLibraryConfig = {
                 id: 'flowfuse-team-library',
                 type: 'flowfuse-team-library',

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -4,7 +4,7 @@ const fs = require('fs/promises')
 const { readFileSync } = require('fs')
 const path = require('path')
 const { log, info, debug, warn, NRlog } = require('./logging/log')
-const { copyDir, hasProperty } = require('./utils')
+const { hasProperty } = require('./utils')
 const { States } = require('./states')
 const { default: got } = require('got')
 
@@ -55,7 +55,6 @@ class Launcher {
             credentials: path.join(this.projectDir, 'flows_cred.json'),
             settings: path.join(this.projectDir, 'settings.js'),
             userSettings: path.join(this.projectDir, 'settings.json'),
-            themeDir: path.join(this.projectDir, 'node_modules', '@flowfuse', 'nr-theme'),
             npmrc: path.join(this.projectDir, '.npmrc')
         }
     }
@@ -80,11 +79,11 @@ class Launcher {
                 packageData.dependencies['@flowfuse/nr-assistant'] = `file:${devPath}`
             }
         }
-        if (!packageData.dependencies['@flowfuse/nr-theme']) {
-            // Ensure the theme package is in package.json so that its resources
-            // don't get removed by npm.
-            packageData.dependencies['@flowfuse/nr-theme'] = '*'
-        }
+        // if (!packageData.dependencies['@flowfuse/nr-theme']) {
+        //     // Ensure the theme package is in package.json so that its resources
+        //     // don't get removed by npm.
+        //     packageData.dependencies['@flowfuse/nr-theme'] = '*'
+        // }
         packageData.version = `0.0.0-${this.snapshot.id}`
         packageData.name = this.snapshot.env.FF_PROJECT_NAME
         if (this.snapshot.name && this.snapshot.description) {
@@ -393,26 +392,6 @@ class Launcher {
         }
     }
 
-    async writeThemeFiles () {
-        info('Updating theme files')
-        const sourceDir1 = path.join(__dirname, '..', 'node_modules', '@flowfuse', 'nr-theme')
-        const sourceDir2 = path.join(__dirname, '..', '..', 'nr-theme')
-        const sourceDir = existsSync(sourceDir1) ? sourceDir1 : sourceDir2
-        const targetDir = path.join(this.projectDir, 'node_modules', '@flowfuse', 'nr-theme')
-        try {
-            if (!existsSync(sourceDir)) {
-                info(`Could not write theme files. Theme not found: '${sourceDir}'`)
-                return
-            }
-            if (!existsSync(targetDir)) {
-                await fs.mkdir(targetDir, { recursive: true })
-            }
-            await copyDir(sourceDir, targetDir, { recursive: true })
-        } catch (error) {
-            info(`Could not write theme files to disk: '${targetDir}'`)
-        }
-    }
-
     async logAuditEvent (event, body) {
         const data = {
             timestamp: Date.now(),
@@ -457,13 +436,6 @@ class Launcher {
             // via CLI/config flag.
             // Rewrite the config file just to be sure
             await this.writeSettings()
-        }
-
-        if (!existsSync(this.files.themeDir)) {
-            // As the theme may not present (due to earlier versions of the agent launcher),
-            // we will independently write the theme files to the device project
-            // (if the directory is not present)
-            await this.writeThemeFiles()
         }
 
         const filterEnv = (env) =>

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,3 @@
-const path = require('path')
-const fs = require('fs').promises
 const proxyFromEnv = require('proxy-from-env')
 
 module.exports = {
@@ -7,7 +5,6 @@ module.exports = {
     compareObjects,
     isObject,
     hasProperty,
-    copyDir,
     getWSProxyAgent,
     getHTTPProxyAgent
 }
@@ -83,39 +80,6 @@ function isObject (object) {
  */
 function hasProperty (object, property) {
     return !!(object && Object.prototype.hasOwnProperty.call(object, property))
-}
-
-/**
- * Copy a directory from one location to another
- * @param {string} src - source directory
- * @param {string} dest - destination directory
- * @param {Object} [options] - options
- * @param {boolean} [options.recursive=true] - whether to copy recursively (default: true)
- */
-async function copyDir (src, dest, { recursive = true } = {}) {
-    // for nodejs v 16.7.0 and later, fs.cp will be available
-    if (fs.cp && typeof fs.cp === 'function') {
-        await fs.cp(src, dest, { recursive })
-        return
-    }
-    // fallback to own implementation of recursive copy (for Node.js 14)
-    // TODO: remove this when Node.js 14 is no longer supported by the device agent
-    const cp = async (src, dest) => {
-        const lstat = await fs.lstat(src).catch(_err => { })
-        if (!lstat) {
-            // do nothing
-        } else if (lstat.isFile()) {
-            await fs.copyFile(src, dest)
-        } else if (lstat.isDirectory()) {
-            await fs.mkdir(dest).catch(_err => { })
-            if (recursive) {
-                for (const f of await fs.readdir(src)) {
-                    await cp(path.join(src, f), path.join(dest, f))
-                }
-            }
-        }
-    }
-    await cp(src, dest)
 }
 
 /**

--- a/test/unit/lib/launcher_spec.js
+++ b/test/unit/lib/launcher_spec.js
@@ -253,32 +253,7 @@ describe('Launcher', function () {
         const npmrc = await fs.readFile(path.join(config.dir, 'project', '.npmrc'))
         npmrc.toString().should.eql('// test\n')
     })
-    it('Writes flowfuse theme files', async function () {
-        const launcher = newLauncher({ config }, null, 'projectId', setup.snapshot)
-        await launcher.writeThemeFiles()
-        const expectedTargetDir = path.join(config.dir, 'project', 'node_modules', '@flowfuse', 'nr-theme')
-        const themeFiles = await fs.readdir(expectedTargetDir)
-        themeFiles.should.containEql('package.json')
-        themeFiles.should.containEql('lib')
-        themeFiles.should.containEql('resources')
 
-        const packageFile = await fs.readFile(path.join(expectedTargetDir, 'package.json'))
-        const packageJSON = JSON.parse(packageFile)
-        packageJSON.should.have.property('name', '@flowfuse/nr-theme')
-
-        // ensure the lib/theme/common, lib/theme/forge-dark and lib/theme/forge-light directories exist
-        const libDir = path.join(expectedTargetDir, 'lib')
-        const themeDir = path.join(libDir, 'theme')
-        const commonDir = path.join(themeDir, 'common')
-        const darkDir = path.join(themeDir, 'forge-dark')
-        const lightDir = path.join(themeDir, 'forge-light')
-        const commonDirStat = await fs.stat(commonDir)
-        const darkDirStat = await fs.stat(darkDir)
-        const lightDirStat = await fs.stat(lightDir)
-        commonDirStat.isDirectory().should.be.true()
-        darkDirStat.isDirectory().should.be.true()
-        lightDirStat.isDirectory().should.be.true()
-    })
     it('Uses custom catalogue when licensed', async function () {
         const licensedConfig = {
             ...config,

--- a/test/unit/lib/template-settings_spec.js
+++ b/test/unit/lib/template-settings_spec.js
@@ -115,7 +115,7 @@ describe('template-settings', () => {
         settings.logging.console.should.have.a.property('metric', false)
         settings.logging.console.should.have.a.property('audit', false)
         settings.logging.console.should.have.a.property('handler').and.be.a.Function()
-        settings.should.have.a.property('nodesDir', null)
+        settings.should.have.a.property('nodesDir')
 
         settings.should.have.a.property('httpNodeAuth', false) // by default, this is false
     })


### PR DESCRIPTION
Closes #356 

## Description

The device agent manually copies the theme plugin resources under the `node_modules` directory within the Node-RED working directory.

When installing or removing any other module, `npm` prunes that directory because the theme module isn't listed in the active `package.json` file. Reloading the editor at that point in time leads to a broken theme as the files are missing. Restarting the agent fixes things as the agent recopies the theme over.


At first, I thought the fix would be to ensure the theme is included in the `dependencies` section of `package.json` so that npm wouldn't prune it.

However, on closer inspection, I can't see why the code is copying the theme over at all. The agent already sets `NODE_PATH` to include the agent's own `node_modules` directory where the theme is installed. I have tests with both Node-RED 4.x and 3.1.15 - they both load the theme from that location without any problems.

I can't find a scenario where the theme needs to be copied over (unless, perhaps, it goes back to a NR 2.x issue... but I don't think that's something we need to cater for today).

Hoping @Steve-Mcl may be able to remember back to when this was first added as to why the copy was being done - but also hopeful we can just remove it.