### PR TITLE
Add user role in auth object

### DIFF
--- a/lib/plugins/node_modules/@flowfuse/flowfuse-auth/adminAuth.js
+++ b/lib/plugins/node_modules/@flowfuse/flowfuse-auth/adminAuth.js
@@ -11,6 +11,7 @@ module.exports = (options) => {
     const clientID = options.clientID
     const clientSecret = options.clientSecret
     const forgeURL = options.forgeURL
+    const teamID = options.teamID
     const baseURL = new URL(options.baseURL)
     let basePath = baseURL.pathname || ''
     if (basePath.endsWith('/')) {
@@ -20,6 +21,7 @@ module.exports = (options) => {
     const authorizationURL = `${forgeURL}/account/authorize`
     const tokenURL = `${forgeURL}/account/token`
     const userInfoURL = `${forgeURL}/api/v1/user`
+    const userTeamRoleURL = `${forgeURL}/api/v1/teams/${teamID}/user`
 
     const oa = new OAuth2(clientID, clientSecret, '', authorizationURL, tokenURL)
 
@@ -61,6 +63,7 @@ module.exports = (options) => {
                 tokenURL,
                 callbackURL,
                 userInfoURL,
+                userTeamRoleURL,
                 scope: `editor-${version}`,
                 clientID,
                 clientSecret,

--- a/lib/plugins/node_modules/@flowfuse/flowfuse-auth/httpAuthMiddleware.js
+++ b/lib/plugins/node_modules/@flowfuse/flowfuse-auth/httpAuthMiddleware.js
@@ -98,12 +98,14 @@ module.exports = {
         const tokenURL = `${options.forgeURL}/account/token`
         const userInfoURL = `${options.forgeURL}/api/v1/user`
         const version = require('../../../../../package.json').version
+        const userTeamRoleURL = `${options.forgeURL}/api/v1/teams/${options.teamID}/user`
 
         passport.use('FlowFuse', new Strategy({
             authorizationURL,
             tokenURL,
             callbackURL,
             userInfoURL,
+            userTeamRoleURL,
             scope: `httpAuth-${version}`,
             clientID: options.clientID,
             clientSecret: options.clientSecret,

--- a/lib/plugins/node_modules/@flowfuse/flowfuse-auth/strategy.js
+++ b/lib/plugins/node_modules/@flowfuse/flowfuse-auth/strategy.js
@@ -2,6 +2,23 @@ const util = require('util')
 const url = require('url')
 const OAuth2Strategy = require('passport-oauth2')
 
+const Roles = {
+    None: 0,
+    Dashboard: 5,
+    Viewer: 10,
+    Member: 30,
+    Owner: 50,
+    Admin: 99
+}
+const RoleNames = {
+    [Roles.None]: 'none',
+    [Roles.Dashboard]: 'dashboard',
+    [Roles.Viewer]: 'viewer',
+    [Roles.Member]: 'member',
+    [Roles.Owner]: 'owner',
+    [Roles.Admin]: 'admin'
+}
+
 function Strategy (options, verify) {
     this.options = options
     this._base = Object.getPrototypeOf(Strategy.prototype)
@@ -25,24 +42,41 @@ util.inherits(Strategy, OAuth2Strategy)
  * MUST be considered 
  */
 
-Strategy.prototype.userProfile = function (accessToken, done) {
+Strategy.prototype.sendAPIRequest = function (url, accessToken, done) {
     this._oauth2.useAuthorizationHeaderforGET(true)
-    this._oauth2.get(this.options.userInfoURL, accessToken, (err, body) => {
+    this._oauth2.get(url, accessToken, (err, body) => {
         if (err) {
             return done(err)
         }
         try {
             const json = JSON.parse(body)
-            done(null, {
-                username: json.username,
-                email: json.email,
-                image: json.avatar,
-                name: json.name,
-                userId: json.id
-            })
+            done(null, json)
         } catch (e) {
             done(e)
         }
+    })
+}
+Strategy.prototype.userProfile = function (accessToken, done) {
+    this._oauth2.useAuthorizationHeaderforGET(true)
+    this.sendAPIRequest(this.options.userInfoURL, accessToken, (err, userProfile) => {
+        if (err) {
+            console.log('Authentication error:', err)
+            return done(err)
+        }
+        this.sendAPIRequest(this.options.userTeamRoleURL, accessToken, (err, userTeamRole) => {
+            if (err) {
+                console.log('Authentication error:', err)
+                return done(err)
+            }
+            done(null, {
+                username: userProfile.username,
+                email: userProfile.email,
+                image: userProfile.avatar,
+                name: userProfile.name,
+                userId: userProfile.id,
+                role: RoleNames[userTeamRole.role] || ''
+            })
+        })
     })
 }
 

--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -212,6 +212,7 @@ if (settings.flowforge.httpNodeAuth?.user && settings.flowforge.httpNodeAuth?.pa
         // pathname (ie '/') from this URL - the domain/etc is not used.
         baseURL: 'https://example.com/',
         forgeURL: settings.flowforge.forgeURL,
+        teamID: settings.flowforge.teamID,
         clientID: settings.flowforge.httpNodeAuth.clientID,
         clientSecret: settings.flowforge.httpNodeAuth.clientSecret
     })


### PR DESCRIPTION
Part of https://github.com/FlowFuse/node-red-dashboard-2-user-addon/issues/21

This updates the Device Agent - there is a near-identical PR in nr-launcher to do there same for hosted instances - [#322](https://github.com/FlowFuse/nr-launcher/pull/322)

This includes the `role` property of the authenticated user when logging into the dashboard.

This required a second API call to get the info; which is mapped from the api-level numeric role to the human readable form.

With this in place, the `msg._client.user` object emitted by FF Dashboard nodes will include the role info:

<img width="267" alt="image" src="https://github.com/user-attachments/assets/1ad779ac-c37c-488d-994f-b9e27ba5345e" />

