### PR TITLE
370 local login

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Node-RED options | Description
 `https`          | Enable HTTPS. See below for details
 `httpStatic`     | Enable serving of static content from a local path
 `httpNodeAuth`   | If set, any endpoints created in Node-RED flows will require this username and password to access them. Default: `false`
+`localAuth`      | When configured, local login is possible
 
 ##### `https` configuration
 
@@ -177,6 +178,20 @@ httpNodeAuth:
    user: user
    pass: $2a$08$zZWtXTja0fB1pzD4sHCMyOCMYz2Z6dNbM6tl8sJogENOMcxWV9DN.
 ```
+
+##### `localAuth` configuration
+
+The recommended way to securely access the Node-RED editor is via FlowFuse platform.
+However, if you want to enable local login within Node-RED, you can use the `localAuth` configuration.
+
+Example:
+```yml
+localAuth:
+   user: user
+   pass: $2a$08$zZWtXTja0fB1pzD4sHCMyOCMYz2Z6dNbM6tl8sJogENOMcxWV9DN.
+```
+
+NOTE: `localAuth.enabled` can be set to `false` to disable local login without the need to remove the `user` and `pass` properties.
 
 
 ### `device.yml` - for provisioning

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const yaml = require('yaml')
+const { hasProperty } = require('./utils')
 
 /**
  * @typedef ConfigOptions
@@ -132,6 +133,32 @@ function parseDeviceConfig (deviceConfig) {
             localConfig.httpNodeAuth = {
                 user: deviceConfig.httpNodeAuth.user,
                 pass: deviceConfig.httpNodeAuth.pass
+            }
+        }
+    }
+
+    if (deviceConfig.localAuth) {
+        if (typeof deviceConfig.localAuth !== 'object') {
+            missing.push('localAuth.user')
+            missing.push('localAuth.pass')
+        } else {
+            const hasEnabledFlag = hasProperty(deviceConfig.localAuth, 'enabled')
+            const enabled = hasEnabledFlag ? deviceConfig.localAuth.enabled : (deviceConfig.localAuth.user || deviceConfig.localAuth.pass)
+            if (enabled) {
+                if (!deviceConfig.localAuth.user) {
+                    missing.push('localAuth.user')
+                } else if (!deviceConfig.localAuth.pass) {
+                    missing.push('localAuth.pass')
+                } else {
+                    localConfig.localAuth = {
+                        user: deviceConfig.localAuth.user,
+                        pass: deviceConfig.localAuth.pass
+                    }
+                }
+            } else {
+                localConfig.localAuth = {
+                    enabled: false
+                }
             }
         }
     }

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -329,6 +329,22 @@ class Launcher {
             }
         }
 
+        if (this.config.localAuth?.enabled) {
+            settings.localAuth = {
+                enabled: true,
+                user: this.config.localAuth.user,
+                pass: this.config.localAuth.pass
+            }
+        } else if (this.settings?.security?.localAuth.enabled === true) {
+            settings.localAuth = {
+                enabled: true,
+                user: this.settings.security.localAuth.user,
+                pass: this.settings.security.localAuth.pass
+            }
+        } else {
+            delete settings.flowforge.localAuth
+        }
+
         await fs.writeFile(this.files.userSettings, JSON.stringify(settings))
     }
 

--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -96,6 +96,17 @@ const auth = {
     }
 }
 
+if (settings.localAuth?.enabled) {
+    auth.type = 'credentials'
+    auth.users = [
+        {
+            username: settings.localAuth.user,
+            password: settings.localAuth.pass,
+            permissions: '*'
+        }
+    ]
+}
+
 const runtimeSettings = {
     flowFile: 'flows.json',
     uiHost: '0.0.0.0',
@@ -162,13 +173,16 @@ const runtimeSettings = {
     [themeName]: { ...themeSettings },
     editorTheme: { ...editorTheme }
 }
-runtimeSettings.editorTheme.login = {
-    message: 'Access the editor through the FlowFuse platform'
-}
-if (themeSettings.projectURL) {
-    runtimeSettings.editorTheme.login.button = {
-        url: themeSettings.projectURL,
-        label: 'Open FlowFuse Dashboard'
+
+if (!settings.localAuth?.enabled) {
+    runtimeSettings.editorTheme.login = {
+        message: 'Access the editor through the FlowFuse platform'
+    }
+    if (themeSettings.projectURL) {
+        runtimeSettings.editorTheme.login.button = {
+            url: themeSettings.projectURL,
+            label: 'Open FlowFuse Dashboard'
+        }
     }
 }
 

--- a/test/unit/lib/AgentManager_spec.js
+++ b/test/unit/lib/AgentManager_spec.js
@@ -100,6 +100,9 @@ httpStatic: /data
 httpNodeAuth:
     user: user
     pass: $2a$08$zZWtXTja0fB1pzD4sHCMyOCMYz2Z6dNbM6tl8sJogENOMcxWV9DN.
+localAuth:
+    user: localuser
+    pass: $2y$08$/IyMCURWoRc4l0ctpJDlJedccKQDftGHC/4iGbKylVGKjUFdW5h3K
 random: 123456
 my_data:
     name: Alice
@@ -181,6 +184,9 @@ my_data:
             deviceConfig.should.match(/httpNodeAuth:/)
             deviceConfig.should.match(/ +user: user/)
             deviceConfig.should.match(/ +pass: \$2a\$08\$zZWtXTja0fB1pzD4sHCMyOCMYz2Z6dNbM6tl8sJogENOMcxWV9DN./)
+            deviceConfig.should.match(/localAuth:/)
+            deviceConfig.should.match(/ +user: localuser/)
+            deviceConfig.should.match(/ +pass: \$2y\$08\$\/IyMCURWoRc4l0ctpJDlJedccKQDftGHC\/4iGbKylVGKjUFdW5h3K/)
             deviceConfig.should.match(/random: 123456/)
             deviceConfig.should.match(/my_data:/)
             deviceConfig.should.match(/ +name: Alice/)

--- a/test/unit/lib/config_spec.js
+++ b/test/unit/lib/config_spec.js
@@ -70,6 +70,7 @@ describe('config loader', () => {
             parsed.should.have.a.property('dir', deviceConfig.dir)
             parsed.should.have.a.property('verbose', true)
             parsed.should.not.have.a.property('httpNodeAuth')
+            parsed.should.not.have.a.property('localAuth')
         })
         describe('httpNodeAuth', () => {
             it('should parse config with httpNodeAuth set false', async function () {
@@ -127,6 +128,81 @@ describe('config loader', () => {
                 parsed.should.have.a.property('valid', false)
                 parsed.should.have.a.property('message').and.be.a.String()
                 parsed.message.should.match(/missing required options.*httpNodeAuth\.pass*/s)
+            })
+        })
+        describe('localAuth', () => {
+            it('should parse config with localAuth set false', async function () {
+                const extraSettings = {
+                    localAuth: false
+                }
+                const ymlData = await generateYaml(extraSettings)
+                const result = parseDeviceConfig(ymlData)
+                should.exist(result)
+                result.should.have.a.property('valid', true)
+                result.should.have.a.property('deviceConfig').and.be.an.Object()
+
+                const parsed = result.deviceConfig
+                parsed.should.have.a.property('localAuth', false)
+            })
+            it('should parse config with valid localAuth settings', async function () {
+                const extraSettings = {
+                    localAuth: {
+                        user: 'user',
+                        pass: 'pass'
+                    }
+                }
+                const ymlData = await generateYaml(extraSettings)
+                const result = parseDeviceConfig(ymlData)
+                should.exist(result)
+                result.should.have.a.property('valid', true)
+                result.should.have.a.property('deviceConfig').and.be.an.Object()
+
+                const parsed = result.deviceConfig
+                parsed.should.have.a.property('localAuth').and.be.an.Object()
+                parsed.localAuth.should.have.a.property('user', 'user')
+                parsed.localAuth.should.have.a.property('pass', 'pass')
+            })
+            it('should parse config with localAuth settings but not enabled', async function () {
+                const extraSettings = {
+                    localAuth: {
+                        enabled: false,
+                        user: 'user',
+                        pass: 'pass'
+                    }
+                }
+                const ymlData = await generateYaml(extraSettings)
+                const result = parseDeviceConfig(ymlData)
+                should.exist(result)
+                result.should.have.a.property('valid', true)
+                result.should.have.a.property('deviceConfig').and.be.an.Object()
+
+                const parsed = result.deviceConfig
+                parsed.should.have.a.property('localAuth').and.be.an.Object()
+                parsed.localAuth.should.have.a.property('enabled', false)
+            })
+            it('should not validate invalid localAuth (string)', async function () {
+                const extraSettings = {
+                    localAuth: 'invalid'
+                }
+                const ymlData = await generateYaml(extraSettings)
+                const result = parseDeviceConfig(ymlData)
+                should.exist(result)
+                result.should.have.a.property('valid', false)
+                result.should.have.a.property('message').and.be.a.String()
+                result.message.should.match(/missing required options.*localAuth\.user*/s)
+            })
+            it('should not validate invalid localAuth (missing pass)', async function () {
+                const extraSettings = {
+                    localAuth: {
+                        user: 'user'
+                    }
+                }
+                const ymlData = await generateYaml(extraSettings)
+                const result = parseDeviceConfig(ymlData)
+                should.exist(result)
+                result.should.have.a.property('valid', false)
+                result.should.have.a.property('message').and.be.a.String()
+                result.message.should.match(/missing required options.*localAuth\.pass*/s)
             })
         })
     })

--- a/test/unit/lib/template-settings_spec.js
+++ b/test/unit/lib/template-settings_spec.js
@@ -56,6 +56,7 @@ describe('template-settings', () => {
         should.exist(settings)
         settings.should.have.a.property('adminAuth').and.be.an.Object()
         settings.adminAuth.should.not.have.a.property('type')
+        settings.adminAuth.should.not.have.a.property('users') // no users array unless localAuth options are provided
 
         settings.should.have.a.property('contextStorage').and.be.an.Object()
         settings.contextStorage.should.have.a.property('default', 'memory')
@@ -200,6 +201,40 @@ describe('template-settings', () => {
         settings.should.have.a.property('httpNodeAuth').and.be.an.Object()
         settings.httpNodeAuth.should.have.a.property('user', 'test')
         settings.httpNodeAuth.should.have.a.property('pass', '$123456789')
+    })
+
+    it('should set adminAuth.type and users array when valid localAuth options are provided and enabled', async function () {
+        const extraConfig = {
+            localAuth: {
+                enabled: true,
+                user: 'local',
+                pass: '$987654321'
+            }
+        }
+        const settingsFile = await generateSettingsFile(extraConfig)
+        const settings = require(settingsFile)
+        should.exist(settings)
+        settings.should.have.a.property('adminAuth').and.be.an.Object()
+        settings.adminAuth.should.have.a.property('type', 'credentials')
+        settings.adminAuth.should.have.a.property('users').and.be.an.Array()
+        settings.adminAuth.users.should.have.length(1)
+        settings.adminAuth.users[0].should.have.a.property('username', 'local')
+        settings.adminAuth.users[0].should.have.a.property('password', '$987654321')
+    })
+    it('should not set adminAuth.type or users array when localAuth options are not enabled', async function () {
+        const extraConfig = {
+            localAuth: {
+                enabled: false,
+                user: 'local',
+                pass: '$987654321'
+            }
+        }
+        const settingsFile = await generateSettingsFile(extraConfig)
+        const settings = require(settingsFile)
+        should.exist(settings)
+        settings.should.have.a.property('adminAuth').and.be.an.Object()
+        settings.adminAuth.should.not.have.a.property('type')
+        settings.adminAuth.should.not.have.a.property('users')
     })
 
     describe('Proxy Support', function () {


### PR DESCRIPTION
closes #370 

## Description

Adds support for local login to Node-RED when settings are provided in the device yaml or supplied from FlowFuse.

NOTE: If local yaml config is provided, it will override the settings provided by FF platform. That includes the ability to disable (see `enabled` flag in below options)

### Device YAML Config options

```yaml
localAuth:
  enabled: true
  user: admin
  pass: $hashed-password
```

### FlowFuse Config options

Provided by the FF platform. See https://github.com/FlowFuse/flowfuse/issues/5358 for details. 


### Unit Tests

#### Updated
```
  Test the AgentManager
    ✔ Agent Manager should request config from FlowFuse when started in provisioning mode (44ms)
  template-settings
    ✔ should load default settings
```

#### New
```
  config loader
    parseDeviceConfig
      localAuth
        ✔ should parse config with localAuth set false
        ✔ should parse config with valid localAuth settings
        ✔ should parse config with localAuth settings but not enabled
        ✔ should not validate invalid localAuth (string)
        ✔ should not validate invalid localAuth (missing pass)

  template-settings
    ✔ should set adminAuth.type and users array when valid localAuth options are provided and enabled
    ✔ should not set adminAuth.type or users array when localAuth options are not enabled
```

## Related Issue(s)

Owner: #370 
Parent: #216

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

