### PR TITLE
Import snapshot during otc setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,10 +258,10 @@ Web UI Options
 
 Setup command
 
-  -o, --otc string         Setup device using a one time code
-  -s, --otc-dont-start     Do not start the agent after setup
-  -n, --otc-dont-import    Do not ask to import Node-RED flows during setup
-  -u, --ff-url url         URL of FlowFuse. Required for setup
+  -o, --otc string    Setup device using a one time code
+  --otc-no-start      Do not start the agent after setup
+  --otc-no-import     Do not ask to import Node-RED flows during setup
+  -u, --ff-url url    URL of FlowFuse. Required for setup
 
 Global Options
 

--- a/README.md
+++ b/README.md
@@ -258,8 +258,10 @@ Web UI Options
 
 Setup command
 
-  -o, --otc string   Setup device using a one time code
-  -u, --ff-url url   URL of FlowFuse. Required for setup
+  -o, --otc string         Setup device using a one time code
+  -s, --otc-dont-start     Do not start the agent after setup
+  -n, --otc-dont-import    Do not ask to import Node-RED flows during setup
+  -u, --ff-url url         URL of FlowFuse. Required for setup
 
 Global Options
 

--- a/index.js
+++ b/index.js
@@ -133,9 +133,9 @@ Please ensure the parent directory is writable, or set a different path with -d`
             print('Success! This Device can be launched at any time using the following command:', figures.tick)
             print(runCommandInfo.join(' '), ' ')
             if (!options.otcNoImport) {
-                // Support for importing flows during initial state check-in was added after 2.15.0.
+                // Support for importing flows during initial state check-in was added after 2.16.0.
                 const ffVersion = deviceSettings.meta?.ffVersion?.replace(/[^0-9.]/g, '') || '0.0.0' // Strip suffixes like -beta.1
-                const ffSupportsImport = (ffVersion && semver.gt(ffVersion, '2.15.0'))
+                const ffSupportsImport = (ffVersion && semver.gt(ffVersion, '2.16.0'))
 
                 if (ffSupportsImport) {
                     const home = process.env.HOME || process.env.USERPROFILE || process.env.HOMEPATH || '/'

--- a/index.js
+++ b/index.js
@@ -15,7 +15,10 @@ const { AgentManager } = require('./lib/AgentManager')
 const { WebServer } = require('./frontend/server')
 const ConfigLoader = require('./lib/config')
 const webServer = new WebServer()
+const figures = require('@inquirer/figures').default
 const confirm = require('@inquirer/confirm').default
+const print = (message, /** @type {figures} */ figure = figures.info) => console.info(figure ?? figures.info, message)
+const flowImport = require('./lib/cli/flowsImporter').flowImport
 
 function main (testOptions) {
     const pkg = require('./package.json')
@@ -111,28 +114,89 @@ Please ensure the parent directory is writable, or set a different path with -d`
             warn('Device setup requires parameter --otc to be 8 or more characters')
             quit(null, 2)
         }
-        info('Entering Device setup...')
+        print('Starting Device setup...')
         if (!options.ffUrl) {
             warn('Device setup requires parameter --ff-url to be set')
             quit(null, 2)
         }
-        AgentManager.quickConnectDevice().then((success) => {
-            if (success) {
-                const runCommandInfo = ['flowfuse-device-agent']
-                if (options.dir !== '/opt/flowfuse-device') {
-                    runCommandInfo.push(`-d ${options.dir}`)
-                }
-                info('Device setup was successful')
-                info('To start the Device Agent with the new configuration run the following command:')
-                info(runCommandInfo.join(' '))
-                if (!options.otcDontStart) {
-                    return confirm({ message: 'Do you want to start the Device Agent now?' })
-                } else {
-                    quit()
-                }
-            } else {
+        let deviceSettings = null
+        AgentManager.quickConnectDevice().then((provisioningData) => {
+            deviceSettings = provisioningData
+            if (!deviceSettings) {
                 warn('Device setup was unsuccessful')
                 quit(null, 2)
+            }
+            const runCommandInfo = ['flowfuse-device-agent']
+            if (options.dir !== '/opt/flowfuse-device') {
+                runCommandInfo.push(`-d ${options.dir}`)
+            }
+            print('Success! This Device can be launched at any time using the following command:', figures.tick)
+            print(runCommandInfo.join(' '), ' ')
+            if (!options.otcDontImport) {
+                // Support for importing flows during initial state check-in was added after 2.15.0.
+                const ffVersion = deviceSettings.meta?.ffVersion?.replace(/[^0-9.]/g, '') || '0.0.0' // Strip suffixes like -beta.1
+                const ffSupportsImport = (ffVersion && semver.gt(ffVersion, '2.15.0'))
+
+                if (ffSupportsImport) {
+                    const home = process.env.HOME || process.env.USERPROFILE || process.env.HOMEPATH || '/'
+                    const suggestedDirs = [path.join(home, '.node-red'), '/opt/flowfuse-device/project']
+                    if (options.dir && options.dir !== '/opt/flowfuse-device') {
+                        suggestedDirs.push(options.dir)
+                        suggestedDirs.push(path.join(options.dir, 'project'))
+                    }
+                    return flowImport(suggestedDirs)
+                }
+            }
+            return Promise.resolve()
+        }).then((importOptions) => {
+            if (importOptions) {
+                const deviceConfig = {
+                    flows: importOptions.flows || [],
+                    credentials: importOptions.credentials || {},
+                    package: importOptions.package || {}
+                }
+                print('Uploading snapshot as the target for this Device...', figures.arrowUp)
+                return AgentManager.postState(
+                    { token: deviceSettings.credentials.token, deviceId: deviceSettings.id, forgeURL: options.ffUrl },
+                    {
+                        provisioning: {
+                            deviceConfig,
+                            credentialSecret: importOptions.credentialSecret,
+                            description: `Flows imported from '${importOptions.flowsFile}' at ${new Date().toISOString()}`,
+                            name: 'Existing Flows Imported'
+                        },
+                        agentVersion: pkg.version,
+                        state: 'provisioning'
+                    }
+                )
+            }
+            return Promise.resolve()
+        }).then((importResponse) => {
+            if (importResponse) {
+                if (importResponse.statusCode === 200) {
+                    // at this point, flowImport has successfully created a snapshot on the platform - we can safely clean up the local files
+                    // check to see if project dir exists & if so, clean it up
+                    const projectDir = path.join(options.dir, 'project')
+                    if (fs.existsSync(projectDir)) {
+                        print('Cleaning up existing project directory...')
+                        fs.rmSync(projectDir, { force: true, recursive: true })
+                    }
+                    const projectJson = path.join(options.dir, 'flowforge-project.json')
+                    if (fs.existsSync(projectJson)) {
+                        print('Cleaning up existing project file...')
+                        fs.rmSync(projectJson, { force: true })
+                    }
+
+                    print('Success', figures.tick)
+                } else {
+                    print(`Snapshot import was unsuccessful (${importResponse.statusCode})`, figures.cross)
+                }
+            }
+            // If the user has set otcDontStart, then we don't want to start the agent
+            if (!options.otcDontStart) {
+                return confirm({ message: 'Do you want to start the Device Agent now?' })
+            } else {
+                quit()
             }
         }).then((startNow) => {
             if (startNow) {

--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ Please ensure the parent directory is writable, or set a different path with -d`
             }
             print('Success! This Device can be launched at any time using the following command:', figures.tick)
             print(runCommandInfo.join(' '), ' ')
-            if (!options.otcDontImport) {
+            if (!options.otcNoImport) {
                 // Support for importing flows during initial state check-in was added after 2.15.0.
                 const ffVersion = deviceSettings.meta?.ffVersion?.replace(/[^0-9.]/g, '') || '0.0.0' // Strip suffixes like -beta.1
                 const ffSupportsImport = (ffVersion && semver.gt(ffVersion, '2.15.0'))
@@ -192,8 +192,8 @@ Please ensure the parent directory is writable, or set a different path with -d`
                     print(`Snapshot import was unsuccessful (${importResponse.statusCode})`, figures.cross)
                 }
             }
-            // If the user has set otcDontStart, then we don't want to start the agent
-            if (!options.otcDontStart) {
+            // If the user has set otcNoStart, then we don't want to start the agent
+            if (!options.otcNoStart) {
                 return confirm({ message: 'Do you want to start the Device Agent now?' })
             } else {
                 quit()

--- a/lib/AgentManager.js
+++ b/lib/AgentManager.js
@@ -363,6 +363,31 @@ class AgentManager {
         return false
     }
 
+    async postState (deviceDetails, state) {
+        if (this.exiting) { return }
+        const { token, deviceId, forgeURL } = deviceDetails
+        if (!token || !deviceId || !forgeURL) {
+            throw new Error('Invalid device details. Cannot post state')
+        }
+        if (!state || typeof state !== 'object') {
+            throw new Error('Invalid state. Cannot post state')
+        }
+
+        this.client = this.client || GOT.extend({})
+
+        return await this.client.post(`${forgeURL}/api/v1/devices/${deviceId}/live/state`, {
+            headers: {
+                'user-agent': `FlowFuse Device Agent v${this.configuration?.version || ' unknown'}`,
+                authorization: `Bearer ${token}`
+            },
+            timeout: {
+                request: 10000
+            },
+            json: state,
+            agent: getHTTPProxyAgent(forgeURL, { timeout: 10000 })
+        })
+    }
+
     // #region Private Methods
     async _getDeviceInfo (forgeURL, token) {
         const ip2mac = {}

--- a/lib/AgentManager.js
+++ b/lib/AgentManager.js
@@ -306,7 +306,7 @@ class AgentManager {
             const provisioningData = JSON.parse(postResponse.body)
             provisioningData.forgeURL = provisioningData.forgeURL || provisioningConfig.forgeURL
             await this._provisionDevice(provisioningData)
-            return true
+            return provisioningData
         } catch (err) {
             warn(`Error provisioning device: ${err.toString()}`)
             throw err

--- a/lib/cli/args.js
+++ b/lib/cli/args.js
@@ -12,7 +12,6 @@ module.exports = [
     {
         name: 'dir',
         description: 'Where the agent should store its state. Default: {underline /opt/flowfuse-device}',
-        alias: 'd',
         type: String,
         // Set default to blank so we can distinguish between it being left as
         // default, and a user setting it explicitly via -d
@@ -117,6 +116,13 @@ module.exports = [
         // defaultValue: false,
         group: 'setup',
         alias: 's'
+    },
+    {
+        name: 'otc-dont-import',
+        description: 'Do not ask to import Node-RED flows during setup',
+        type: Boolean,
+        alias: 'n',
+        group: 'setup'
     },
     {
         name: 'ff-url',

--- a/lib/cli/args.js
+++ b/lib/cli/args.js
@@ -12,6 +12,7 @@ module.exports = [
     {
         name: 'dir',
         description: 'Where the agent should store its state. Default: {underline /opt/flowfuse-device}',
+        alias: 'd',
         type: String,
         // Set default to blank so we can distinguish between it being left as
         // default, and a user setting it explicitly via -d

--- a/lib/cli/args.js
+++ b/lib/cli/args.js
@@ -111,18 +111,16 @@ module.exports = [
         group: 'setup'
     },
     {
-        name: 'otc-dont-start',
+        name: 'otc-no-start',
         description: 'Do not start the agent after setup',
         type: Boolean,
         // defaultValue: false,
-        group: 'setup',
-        alias: 's'
+        group: 'setup'
     },
     {
-        name: 'otc-dont-import',
+        name: 'otc-no-import',
         description: 'Do not ask to import Node-RED flows during setup',
         type: Boolean,
-        alias: 'n',
         group: 'setup'
     },
     {

--- a/lib/cli/flowsImporter.js
+++ b/lib/cli/flowsImporter.js
@@ -1,0 +1,275 @@
+const { existsSync, statSync } = require('node:fs')
+const { promises: fsPromises } = require('node:fs')
+const path = require('node:path')
+const { getPackageData, extractKeyValueFromJsContent, loadAndParseJsonFile } = require('../utils')
+const select = require('@inquirer/select').default
+const input = require('@inquirer/input').default
+const confirm = require('@inquirer/confirm').default
+const figures = require('@inquirer/figures').default
+const print = (message, /** @type {figures} */ figure = figures.info) => console.info(figure ?? figures.info, message)
+
+const CHOICES = {
+    SKIP: false, // skip import
+    CUSTOM: -2 // custom path
+}
+
+/**
+ * Asks the user if they want to import existing Node-RED flows from a directory.
+ * If the user chooses to import, they can select from existing directories or enter a custom path.
+ * If the user chooses to skip, the function returns false.
+ * If the user chooses a custom path, the function returns the path as a string.
+ * @param {*} [options] - Options object containing the `dir` to check for existing flows of an existing agent directory
+ * @returns {Promise<{skip:Boolean,valid:Boolean,dir:string,flowFiles:Array}>}
+ */
+async function askImportDirectory (suggestedDirs) {
+    // get details for each suggested directory
+    let suggestedDirDetails = []
+    if (suggestedDirs?.length > 0) {
+        suggestedDirDetails = await Promise.all(suggestedDirs.map(async (dir) => {
+            const dirDetails = await getDirDetails(dir)
+            if (dirDetails.valid) {
+                return dirDetails
+            }
+            return null
+        }))
+        suggestedDirDetails = suggestedDirDetails.filter(dir => dir !== null)
+    }
+
+    let choice = CHOICES.SKIP
+    if (suggestedDirDetails.length > 0) {
+        const choices = []
+        choices.push({ name: 'Skip import', value: CHOICES.SKIP, description: 'Press <enter> to skip import' })
+        suggestedDirDetails.forEach(dirDetails => {
+            const flowsCount = dirDetails.flowFiles.length
+            choices.push({ name: dirDetails.userDir, value: dirDetails, description: `Press <enter> to select this directory (contains ${flowsCount} Node-RED flows file${flowsCount > 1 ? 's' : ''})` })
+        })
+        choices.push({ name: 'Custom path...', value: CHOICES.CUSTOM, description: 'Manually enter the path to a Node-RED directory' })
+        choice = await select({
+            message: 'Import existing Node-RED flows?',
+            choices,
+            pageSize: 10,
+            instructions: { navigation: 'Use arrow keys to navigate, press <enter> to confirm' }
+        })
+    } else {
+        const answer = await confirm({
+            message: 'Import existing Node-RED flows?',
+            default: false
+        })
+
+        if (answer) {
+            choice = CHOICES.CUSTOM
+        }
+    }
+    let details = null
+    if (choice === CHOICES.CUSTOM) {
+        const customPath = await input({
+            message: 'Enter the path to your Node-RED directory (leave blank to cancel):',
+            validate: async (input) => {
+                details = null
+                if (!input.trim()) {
+                    return true
+                }
+                if (!existsSync(input)) {
+                    return 'Path does not exist.'
+                }
+                if (!statSync(input).isDirectory()) {
+                    return 'Path is not a directory.'
+                }
+                // check to see if any of the files in the directory are Node-RED flows files
+                details = await getDirDetails(input)
+                if (!details?.valid) {
+                    return `'${input}' does not contain any Node-RED flows files.`
+                }
+                return true
+            }
+        })
+        if (customPath.trim() === '') {
+            return CHOICES.SKIP
+        }
+        return details
+    }
+    if (choice === CHOICES.SKIP) {
+        return {
+            skip: true
+        }
+    }
+
+    return choice
+}
+
+/**
+ * Asks the user to select from the supplied list.
+ * @param {Array<{isFlowsFile:Boolean,name:string,flowsFile:string,credsFile:string,description:string}>} flowFiles - The array of flow details
+ * @returns {Promise<{isFlowsFile:Boolean,name:string,flowsFile:string,credsFile:string,description:string}>}
+ */
+async function askSelectFlowsFile (flowFiles) {
+    if (!flowFiles?.length) {
+        return false
+    }
+
+    const choices = flowFiles.map(e => ({ name: e.name, value: e, description: e.description }))
+    choices.unshift({ name: 'Skip import', value: false, description: 'Press <enter> to skip import' })
+    let defaultChoice = choices[1].value
+    if (flowFiles.length > 1) {
+        defaultChoice = flowFiles.find(e => e.name === 'flows.json') || defaultChoice
+    }
+    const choice = await select({
+        message: 'Select a flows file:',
+        choices,
+        pageSize: 10,
+        default: defaultChoice,
+        instructions: { navigation: 'Use arrow keys to navigate, press <enter> to confirm' }
+    })
+
+    return choice || false
+}
+
+async function getDirDetails (dir) {
+    const userDir = path.resolve(dir)
+    const flowFiles = await getFlowFiles(userDir)
+    if (flowFiles.length > 0) {
+        const result = {
+            valid: true,
+            userDir,
+            flowFiles,
+            packageFile: path.join(userDir, 'package.json')
+        }
+        return result
+    }
+    return {
+        valid: false,
+        userDir,
+        flowFiles: [],
+        packageFile: path.join(userDir, 'package.json')
+    }
+}
+
+async function getFlowFiles (userDir) {
+    if (!userDir) {
+        return []
+    }
+    if (!existsSync(userDir) || !statSync(userDir).isDirectory()) {
+        return []
+    }
+    if (!existsSync(path.join(userDir, 'package.json'))) {
+        return []
+    }
+
+    const jsonFiles = [] // array of *.json files in the userDir
+    const files = await fsPromises.readdir(userDir)
+    for (const file of files) {
+        // skip the following files:
+        // - package.json
+        // - *_cred.json
+        // - .config*.json
+        const skipFiles = [
+            /package\.json/,
+            /.+_cred\.json/,
+            /\.config.*\.json/
+        ]
+        const skipFile = !!skipFiles.find(skipFile => new RegExp(skipFile).test(file))
+        if (file.endsWith('.json') && !skipFile) {
+            // check if the file is a Node-RED flows file or a Node-RED credentials file
+            const flowsFileDetails = await getFlowsFileDetails(userDir, file)
+            if (flowsFileDetails?.isFlowsFile) {
+                jsonFiles.push(flowsFileDetails)
+            }
+        }
+    }
+    return jsonFiles
+}
+
+async function getFlowsFileDetails (dir, file) {
+    const filePath = path.join(dir, file)
+    const userDir = path.dirname(filePath)
+    const result = {
+        isFlowsFile: false,
+        userDir,
+        name: file,
+        flowsFile: filePath,
+        credsFile: null,
+        description: 'Not a valid Node-RED flows file'
+    }
+    try {
+        const fileData = await fsPromises.readFile(filePath, 'utf8')
+        const flows = JSON.parse(fileData)
+        if (Array.isArray(flows)) {
+            const duckTypeTest = flows.every(node => typeof node.id === 'string' && typeof node.type === 'string' && node.id.length > 0 && node.type.length > 0)
+            if (!duckTypeTest) {
+                return result
+            }
+            result.isFlowsFile = true
+            result.description = `Press <enter> to import '${file}'`
+            result.flows = flows
+            const credFile = filePath.replace(/\.json$/, '_cred.json')
+            if (existsSync(credFile)) {
+                result.credsFile = credFile
+            }
+            return result
+        }
+        return JSON.parse(fileData)
+    } catch (error) {
+        // Ignore errors
+    }
+    return result
+}
+
+async function flowImport (suggestedDirs) {
+    const importDetails = await askImportDirectory(suggestedDirs)
+    if (importDetails === CHOICES.SKIP || importDetails.skip || !importDetails?.valid) {
+        return null
+    }
+    const selectedFlows = await askSelectFlowsFile(importDetails.flowFiles)
+    if (selectedFlows) {
+        const userDir = path.dirname(selectedFlows.flowsFile)
+        selectedFlows.credentials = {} // default to empty credentials
+        selectedFlows.credentialSecret = null // default to null
+        selectedFlows.packageFile = path.join(userDir, 'package.json')
+        if (selectedFlows.credsFile && existsSync(selectedFlows.credsFile)) {
+            print(`Importing credentials '${selectedFlows.credsFile}'...`)
+            selectedFlows.credentials = await fsPromises.readFile(selectedFlows.credsFile, 'utf8')
+            selectedFlows.credentials = JSON.parse(selectedFlows.credentials)
+            // now, see if we can locate the credentialSecret for the creds file
+
+            // 1. check the .config.runtime.json file for the credentialSecret
+            const data = loadAndParseJsonFile(path.join(userDir, '.config.runtime.json'))
+            selectedFlows.credentialSecret = data?._credentialSecret ?? null
+
+            // 2. check if settings.json file has credentialSecret (this is where FF stores it)
+            if (!selectedFlows.credentialSecret) {
+                const data = loadAndParseJsonFile(path.join(userDir, 'settings.json'))
+                selectedFlows.credentialSecret = data?.credentialSecret ?? null
+            }
+
+            // 3. check if settings.js file has credentialSecret (this is where FF stores it)
+            if (!selectedFlows.credentialSecret) {
+                try {
+                    const settingsFile = path.join(userDir, 'settings.js')
+                    if (existsSync(settingsFile)) {
+                        const settings = await fsPromises.readFile(settingsFile, 'utf8')
+                        selectedFlows.credentialSecret = settings ? extractKeyValueFromJsContent(settings || '', 'credentialSecret') : null
+                    }
+                } catch (error) {
+                    selectedFlows.credentialSecret = null
+                }
+            }
+
+            if (!selectedFlows.credentialSecret) {
+                print('Could not determine the credentials secret. Flows will be imported without credentials.', figures.warning)
+                selectedFlows.credentials = {}
+            }
+        } else {
+            selectedFlows.credentials = {}
+        }
+        print(`Importing package '${selectedFlows.packageFile}'...`)
+        selectedFlows.package = getPackageData(selectedFlows.packageFile, { convertFileModulesToLatest: true })
+        return selectedFlows
+    }
+    return null
+}
+
+module.exports = {
+    askSelectFlowsFile,
+    askImportDirectory,
+    flowImport
+}

--- a/lib/cli/flowsImporter.js
+++ b/lib/cli/flowsImporter.js
@@ -1,7 +1,7 @@
 const { existsSync, statSync } = require('node:fs')
 const { promises: fsPromises } = require('node:fs')
 const path = require('node:path')
-const { getPackageData, extractKeyValueFromJsContent, loadAndParseJsonFile } = require('../utils')
+const utils = require('../utils')
 const select = require('@inquirer/select').default
 const input = require('@inquirer/input').default
 const confirm = require('@inquirer/confirm').default
@@ -85,6 +85,10 @@ async function askImportDirectory (suggestedDirs) {
         })
         if (customPath.trim() === '') {
             return CHOICES.SKIP
+        }
+        if (customPath && !details) {
+            // tests do not cause the validate function to be called, so we need to update the details here
+            details = await getDirDetails(customPath)
         }
         return details
     }
@@ -207,7 +211,6 @@ async function getFlowsFileDetails (dir, file) {
             }
             return result
         }
-        return JSON.parse(fileData)
     } catch (error) {
         // Ignore errors
     }
@@ -215,11 +218,13 @@ async function getFlowsFileDetails (dir, file) {
 }
 
 async function flowImport (suggestedDirs) {
-    const importDetails = await askImportDirectory(suggestedDirs)
+    const __askImportDirectory = module.exports.askImportDirectory // use the module definition so that mock tests can override it
+    const __askSelectFlowsFile = module.exports.askSelectFlowsFile
+    const importDetails = await __askImportDirectory(suggestedDirs)
     if (importDetails === CHOICES.SKIP || importDetails.skip || !importDetails?.valid) {
         return null
     }
-    const selectedFlows = await askSelectFlowsFile(importDetails.flowFiles)
+    const selectedFlows = await __askSelectFlowsFile(importDetails.flowFiles)
     if (selectedFlows) {
         const userDir = path.dirname(selectedFlows.flowsFile)
         selectedFlows.credentials = {} // default to empty credentials
@@ -232,12 +237,12 @@ async function flowImport (suggestedDirs) {
             // now, see if we can locate the credentialSecret for the creds file
 
             // 1. check the .config.runtime.json file for the credentialSecret
-            const data = loadAndParseJsonFile(path.join(userDir, '.config.runtime.json'))
+            const data = utils.loadAndParseJsonFile(path.join(userDir, '.config.runtime.json'))
             selectedFlows.credentialSecret = data?._credentialSecret ?? null
 
             // 2. check if settings.json file has credentialSecret (this is where FF stores it)
             if (!selectedFlows.credentialSecret) {
-                const data = loadAndParseJsonFile(path.join(userDir, 'settings.json'))
+                const data = utils.loadAndParseJsonFile(path.join(userDir, 'settings.json'))
                 selectedFlows.credentialSecret = data?.credentialSecret ?? null
             }
 
@@ -247,7 +252,7 @@ async function flowImport (suggestedDirs) {
                     const settingsFile = path.join(userDir, 'settings.js')
                     if (existsSync(settingsFile)) {
                         const settings = await fsPromises.readFile(settingsFile, 'utf8')
-                        selectedFlows.credentialSecret = settings ? extractKeyValueFromJsContent(settings || '', 'credentialSecret') : null
+                        selectedFlows.credentialSecret = settings ? utils.extractKeyValueFromJsContent(settings || '', 'credentialSecret') : null
                     }
                 } catch (error) {
                     selectedFlows.credentialSecret = null
@@ -262,14 +267,17 @@ async function flowImport (suggestedDirs) {
             selectedFlows.credentials = {}
         }
         print(`Importing package '${selectedFlows.packageFile}'...`)
-        selectedFlows.package = getPackageData(selectedFlows.packageFile, { convertFileModulesToLatest: true })
+        selectedFlows.package = utils.getPackageData(selectedFlows.packageFile, { convertFileModulesToLatest: true })
         return selectedFlows
     }
     return null
 }
 
 module.exports = {
-    askSelectFlowsFile,
     askImportDirectory,
+    askSelectFlowsFile,
+    getDirDetails,
+    getFlowFiles,
+    getFlowsFileDetails,
     flowImport
 }

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -1,10 +1,9 @@
 const childProcess = require('child_process')
 const { existsSync } = require('fs')
 const fs = require('fs/promises')
-const { readFileSync } = require('fs')
 const path = require('path')
 const { log, info, debug, warn, NRlog } = require('./logging/log')
-const { hasProperty } = require('./utils')
+const { hasProperty, getPackageData } = require('./utils')
 const { States } = require('./states')
 const { default: got } = require('got')
 
@@ -96,23 +95,17 @@ class Launcher {
 
     readPackage () {
         debug(`Reading package.json: ${this.files.packageJSON}`)
-        const data = {
+        try {
+            return getPackageData(this.files.packageJSON)
+        } catch (e) {
+            console.error(e)
+        }
+        return {
             modules: {},
             version: '',
             name: '',
             description: ''
         }
-        try {
-            const packageJSON = readFileSync(this.files.packageJSON)
-            const packageData = JSON.parse(packageJSON)
-            data.modules = packageData.dependencies
-            data.version = packageData.version
-            data.name = packageData.name
-            data.description = packageData.descriptions
-        } catch (e) {
-            console.error(e)
-        }
-        return data
     }
 
     async installDependencies () {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -185,7 +185,10 @@ function getPackageData (packageJsonFile, options) {
 
 /**
  * Extracts the value of a specified key from a JavaScript object string, ignoring comments.
- * Typically used to grab the credentialSecret from a Node-RED settings.js file.
+ * Typically used to grab the `credentialSecret` from a Node-RED settings.js file.
+ * NOTE: This is a basic implementation and may not cover all edge cases. For example,
+ * it does not evaluate the JavaScript code, so it won't work for complex expressions or multi-line values.
+ * Additionally, it assumes that the key-value pairs on their own lines (i.e. minified code may not work)
  * @param {string} jsContent - The JavaScript content as a string.
  * @param {string} keyName - The name of the key to extract the value for.
  * @returns {string|null} - The value of the key if found, otherwise null.
@@ -200,7 +203,6 @@ function extractKeyValueFromJsContent (jsContent, keyName) {
     const escapedKeyName = keyName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // $& means the whole matched string
 
     // 1. Remove block comments.
-    //    This regex is a basic attempt; for complex cases, a proper parser is better.
     const contentWithoutBlockComments = jsContent.replace(/\/\*[\s\S]*?\*\//g, '')
 
     // 2. Use a regex to find the uncommented key line and extract the value.
@@ -222,6 +224,12 @@ function extractKeyValueFromJsContent (jsContent, keyName) {
         return null
     }
 }
+
+/**
+ * Load and parse a JSON file
+ * * @param {string} filePath - The path to the JSON file.
+ * * @returns {Object|null} - The parsed JSON object, or null if the file doesn't exist or is invalid.
+ */
 function loadAndParseJsonFile (filePath) {
     try {
         if (fs.existsSync(filePath)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,4 @@
-const { readFileSync, existsSync } = require('fs')
+const fs = require('fs')
 const proxyFromEnv = require('proxy-from-env')
 
 module.exports = {
@@ -163,7 +163,7 @@ function getPackageData (packageJsonFile, options) {
         name: '',
         description: ''
     }
-    const packageJSON = readFileSync(packageJsonFile)
+    const packageJSON = fs.readFileSync(packageJsonFile)
     const packageData = JSON.parse(packageJSON)
     data.modules = packageData.dependencies
     data.version = packageData.version
@@ -224,8 +224,8 @@ function extractKeyValueFromJsContent (jsContent, keyName) {
 }
 function loadAndParseJsonFile (filePath) {
     try {
-        if (existsSync(filePath)) {
-            const settingsData = readFileSync(filePath, 'utf8')
+        if (fs.existsSync(filePath)) {
+            const settingsData = fs.readFileSync(filePath, 'utf8')
             return JSON.parse(settingsData)
         }
     } catch (error) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,4 @@
+const { readFileSync, existsSync } = require('fs')
 const proxyFromEnv = require('proxy-from-env')
 
 module.exports = {
@@ -6,7 +7,10 @@ module.exports = {
     isObject,
     hasProperty,
     getWSProxyAgent,
-    getHTTPProxyAgent
+    getHTTPProxyAgent,
+    getPackageData,
+    extractKeyValueFromJsContent,
+    loadAndParseJsonFile
 }
 
 /**
@@ -149,4 +153,82 @@ function getHTTPProxyAgent (url, proxyOptions) {
         }
     }
     return agent
+}
+
+function getPackageData (packageJsonFile, options) {
+    options = options || {}
+    const data = {
+        modules: {},
+        version: '',
+        name: '',
+        description: ''
+    }
+    const packageJSON = readFileSync(packageJsonFile)
+    const packageData = JSON.parse(packageJSON)
+    data.modules = packageData.dependencies
+    data.version = packageData.version
+    data.name = packageData.name
+    data.description = packageData.description
+
+    if (options.convertFileModulesToLatest) {
+        const modules = data.modules || {}
+        for (const key in modules) {
+            if (modules[key] && modules[key].startsWith('file:')) {
+                modules[key] = '*'
+            }
+        }
+        data.modules = modules
+    }
+
+    return data
+}
+
+/**
+ * Extracts the value of a specified key from a JavaScript object string, ignoring comments.
+ * Typically used to grab the credentialSecret from a Node-RED settings.js file.
+ * @param {string} jsContent - The JavaScript content as a string.
+ * @param {string} keyName - The name of the key to extract the value for.
+ * @returns {string|null} - The value of the key if found, otherwise null.
+ */
+function extractKeyValueFromJsContent (jsContent, keyName) {
+    if (typeof jsContent !== 'string' || typeof keyName !== 'string' || keyName.length === 0) {
+        console.error('Invalid input: jsContent must be a string and keyName must be a non-empty string.')
+        return null
+    }
+
+    // Escape the keyName in case it contains special regex characters.
+    const escapedKeyName = keyName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // $& means the whole matched string
+
+    // 1. Remove block comments.
+    //    This regex is a basic attempt; for complex cases, a proper parser is better.
+    const contentWithoutBlockComments = jsContent.replace(/\/\*[\s\S]*?\*\//g, '')
+
+    // 2. Use a regex to find the uncommented key line and extract the value.
+    //    - ^\s*: Matches the start of a line followed by optional whitespace.
+    //    - ${escapedKeyName}:\s*: Matches the provided key name and colon followed by optional whitespace.
+    //    - (['"]): Captures the opening quote (either single or double) into group 1.
+    //    - (.*?): Captures the value inside the quotes (non-greedily) into group 2.
+    //    - \1: Matches the same character captured in group 1 (the closing quote).
+    //    - m flag: Enables multiline mode, so ^ and $ match start/end of lines.
+    const valueMatch = contentWithoutBlockComments.match(
+        new RegExp(`^\\s*${escapedKeyName}:\\s*(['"])(.*?)\\1`, 'm')
+    )
+
+    if (valueMatch && valueMatch[2]) {
+        // The value is in the second capturing group
+        return valueMatch[2]
+    } else {
+        // Not found or commented out in a way the regex doesn't catch
+        return null
+    }
+}
+function loadAndParseJsonFile (filePath) {
+    try {
+        if (existsSync(filePath)) {
+            const settingsData = readFileSync(filePath, 'utf8')
+            return JSON.parse(settingsData)
+        }
+    } catch (error) {
+    }
+    return null
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
             "dependencies": {
                 "@flowfuse/nr-theme": "^1.8.0",
                 "@inquirer/confirm": "^5.1.9",
+                "@inquirer/input": "^4.1.9",
+                "@inquirer/select": "^4.2.0",
                 "command-line-args": "^5.2.1",
                 "command-line-usage": "^6.1.3",
                 "express-session": "^1.18.0",
@@ -252,6 +254,51 @@
             "integrity": "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==",
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/@inquirer/input": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.9.tgz",
+            "integrity": "sha512-mshNG24Ij5KqsQtOZMgj5TwEjIf+F2HOESk6bjMwGWgcH5UBe8UoljwzNFHqdMbGYbgAf6v2wU/X9CAdKJzgOA==",
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/type": "^3.0.6"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/select": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.2.0.tgz",
+            "integrity": "sha512-KkXQ4aSySWimpV4V/TUJWdB3tdfENZUU765GjOIZ0uPwdbGIG6jrxD4dDf1w68uP+DVtfNhr1A92B+0mbTZ8FA==",
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/figures": "^1.0.11",
+                "@inquirer/type": "^3.0.6",
+                "ansi-escapes": "^4.3.2",
+                "yoctocolors-cjs": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@inquirer/type": {
@@ -5082,6 +5129,27 @@
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
             "integrity": "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw=="
+        },
+        "@inquirer/input": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.9.tgz",
+            "integrity": "sha512-mshNG24Ij5KqsQtOZMgj5TwEjIf+F2HOESk6bjMwGWgcH5UBe8UoljwzNFHqdMbGYbgAf6v2wU/X9CAdKJzgOA==",
+            "requires": {
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/type": "^3.0.6"
+            }
+        },
+        "@inquirer/select": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.2.0.tgz",
+            "integrity": "sha512-KkXQ4aSySWimpV4V/TUJWdB3tdfENZUU765GjOIZ0uPwdbGIG6jrxD4dDf1w68uP+DVtfNhr1A92B+0mbTZ8FA==",
+            "requires": {
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/figures": "^1.0.11",
+                "@inquirer/type": "^3.0.6",
+                "ansi-escapes": "^4.3.2",
+                "yoctocolors-cjs": "^2.1.2"
+            }
         },
         "@inquirer/type": {
             "version": "3.0.6",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "dependencies": {
         "@flowfuse/nr-theme": "^1.8.0",
         "@inquirer/confirm": "^5.1.9",
+        "@inquirer/input": "^4.1.9",
+        "@inquirer/select": "^4.2.0",
         "command-line-args": "^5.2.1",
         "command-line-usage": "^6.1.3",
         "express-session": "^1.18.0",

--- a/test/unit/lib/cli/flowsImporter_spec.js
+++ b/test/unit/lib/cli/flowsImporter_spec.js
@@ -1,0 +1,436 @@
+const mocha = require('mocha') // eslint-disable-line
+const should = require('should')
+const sinon = require('sinon')
+const path = require('path')
+const fs = require('fs/promises')
+const os = require('os')
+const utils = require('../../../../lib/utils')
+const Select = require('@inquirer/select')
+const Input = require('@inquirer/input')
+const Confirm = require('@inquirer/confirm')
+
+/** @type {import('../../../../lib/cli/flowsImporter')} */
+let flowsImporter
+
+describe('Flows Importer', function () {
+    let sandbox
+    let tempDir
+    let testFlowsDir
+    let mockFlowsFile
+    let mockCredsFile
+    let mockPackageFile
+
+    const mockFlows = [
+        { id: 'node1', type: 'tab', label: 'Flow 1' },
+        { id: 'node2', type: 'inject', name: 'Inject node' }
+    ]
+
+    const mockCredentials = {
+        node2: {
+            user: 'encryptedcreds'
+        }
+    }
+
+    const mockPackageData = {
+        name: 'test-flows',
+        dependencies: {
+            'node-red': '^4.0.9',
+            'node-red-contrib-test': '^1.0.0'
+        }
+    }
+
+    beforeEach(async function () {
+        sandbox = sinon.createSandbox()
+        tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ff-flows-importer-'))
+        testFlowsDir = path.join(tempDir, 'node-red')
+        await fs.mkdir(testFlowsDir, { recursive: true })
+
+        // Create mock files
+        mockFlowsFile = path.join(testFlowsDir, 'flows.json')
+        mockCredsFile = path.join(testFlowsDir, 'flows_cred.json')
+        mockPackageFile = path.join(testFlowsDir, 'package.json')
+
+        await fs.writeFile(mockFlowsFile, JSON.stringify(mockFlows))
+        await fs.writeFile(mockCredsFile, JSON.stringify(mockCredentials))
+        await fs.writeFile(mockPackageFile, JSON.stringify(mockPackageData))
+
+        // Stub inquirer components
+        sandbox.stub(Select, 'default')
+        sandbox.stub(Input, 'default')
+        sandbox.stub(Confirm, 'default')
+
+        // now the stubs are set we can require the flowsImporter module
+        // but first, clear the require cache to ensure we get a fresh instance
+        delete require.cache[require.resolve('../../../../lib/cli/flowsImporter')]
+        flowsImporter = require('../../../../lib/cli/flowsImporter')
+
+        // Stub console.info to prevent output during tests
+        sandbox.stub(console, 'info')
+    })
+
+    afterEach(async function () {
+        sandbox.restore()
+        await fs.rm(tempDir, { recursive: true, force: true })
+    })
+
+    describe('getFlowsFileDetails', function () {
+        it('should identify a valid Node-RED flows file', async function () {
+            const result = await flowsImporter.getFlowsFileDetails(testFlowsDir, 'flows.json')
+
+            result.should.have.property('isFlowsFile', true)
+            result.should.have.property('name', 'flows.json')
+            result.should.have.property('flowsFile', mockFlowsFile)
+            result.should.have.property('credsFile', mockCredsFile)
+            result.should.have.property('flows').and.be.an.Array()
+        })
+
+        it('should reject an invalid JSON file', async function () {
+            const invalidFile = path.join(testFlowsDir, 'invalid.json')
+            await fs.writeFile(invalidFile, 'not valid json')
+
+            const result = await flowsImporter.getFlowsFileDetails(testFlowsDir, 'invalid.json')
+            result.should.have.property('isFlowsFile', false)
+        })
+
+        it('should reject a JSON file that is not a Node-RED flows file', async function () {
+            const nonFlowsFile = path.join(testFlowsDir, 'not-flows.json')
+            await fs.writeFile(nonFlowsFile, JSON.stringify({ something: 'else' }))
+
+            const result = await flowsImporter.getFlowsFileDetails(testFlowsDir, 'not-flows.json')
+            result.should.have.property('isFlowsFile', false)
+        })
+    })
+
+    describe('getFlowFiles', function () {
+        it('should find Node-RED flows files in a directory', async function () {
+            // Create additional flows file
+            const additionalFlows = path.join(testFlowsDir, 'flows-backup.json')
+            await fs.writeFile(additionalFlows, JSON.stringify(mockFlows))
+
+            const result = await flowsImporter.getFlowFiles(testFlowsDir)
+
+            result.should.be.an.Array()
+            result.should.have.length(2)
+            result[0].should.have.property('isFlowsFile', true)
+            result[1].should.have.property('isFlowsFile', true)
+        })
+
+        it('should ignore files that are not flows files', async function () {
+            // Create non-flows files
+            await fs.writeFile(path.join(testFlowsDir, '.config.json'), '{}')
+            await fs.writeFile(path.join(testFlowsDir, 'something_cred.json'), '{}')
+
+            const result = await flowsImporter.getFlowFiles(testFlowsDir)
+
+            result.should.be.an.Array()
+            result.should.have.length(1) // only the flows.json file
+        })
+
+        it('should return empty array for invalid directory', async function () {
+            const result = await flowsImporter.getFlowFiles('/path/does/not/exist')
+            result.should.be.an.Array().and.be.empty()
+        })
+
+        it('should return empty array if package.json does not exist', async function () {
+            const noPkgDir = path.join(tempDir, 'no-pkg')
+            await fs.mkdir(noPkgDir)
+            await fs.writeFile(path.join(noPkgDir, 'flows.json'), JSON.stringify(mockFlows))
+
+            const result = await flowsImporter.getFlowFiles(noPkgDir)
+            result.should.be.an.Array().and.be.empty()
+        })
+    })
+
+    describe('getDirDetails', function () {
+        it('should return valid directory details', async function () {
+            const result = await flowsImporter.getDirDetails(testFlowsDir)
+
+            result.should.have.property('valid', true)
+            result.should.have.property('userDir', testFlowsDir)
+            result.should.have.property('flowFiles').and.be.an.Array()
+            result.should.have.property('packageFile', path.join(testFlowsDir, 'package.json'))
+        })
+
+        it('should return invalid details for directory without flows', async function () {
+            const emptyDir = path.join(tempDir, 'empty')
+            await fs.mkdir(emptyDir)
+            await fs.writeFile(path.join(emptyDir, 'package.json'), '{}')
+
+            const result = await flowsImporter.getDirDetails(emptyDir)
+            result.should.have.property('valid', false)
+            result.should.have.property('flowFiles').and.be.an.Array().and.be.empty()
+        })
+    })
+
+    describe('askSelectFlowsFile', function () {
+        it('should prompt user to select a flows file', async function () {
+            const mockFlowFiles = [
+                { name: 'flows.json', description: 'description 1', isFlowsFile: true },
+                { name: 'flows2.json', description: 'description 2', isFlowsFile: true }
+            ]
+
+            Select.default.resolves(mockFlowFiles[0])
+
+            const result = await flowsImporter.askSelectFlowsFile(mockFlowFiles)
+
+            Select.default.calledOnce.should.be.true()
+            result.should.deepEqual(mockFlowFiles[0])
+        })
+
+        it('should return false if user selects skip', async function () {
+            const mockFlowFiles = [
+                { name: 'flows.json', description: 'description 1', isFlowsFile: true }
+            ]
+
+            Select.default.resolves(false)
+            // read the stdin to simulate user input
+            const result = await flowsImporter.askSelectFlowsFile(mockFlowFiles)
+            result.should.be.false()
+        })
+
+        it('should return false if no flow files are provided', async function () {
+            const result = await flowsImporter.askSelectFlowsFile([])
+            result.should.be.false()
+        })
+
+        it('should prompt user to select a flows file', async function () {
+            const mockFlowFiles = [
+                { name: 'flows.json', description: 'description 1', isFlowsFile: true },
+                { name: 'flows2.json', description: 'description 2', isFlowsFile: true }
+            ]
+
+            Select.default.resolves(mockFlowFiles[0])
+
+            const result = await flowsImporter.askSelectFlowsFile(mockFlowFiles)
+
+            Select.default.calledOnce.should.be.true()
+            result.should.deepEqual(mockFlowFiles[0])
+        })
+    })
+
+    describe('askImportDirectory', function () {
+        it('should return directory details if user selects a suggested directory', async function () {
+            const mockDirDetails = { valid: true, userDir: testFlowsDir, flowFiles: [{ name: 'flows.json' }] }
+
+            // Stub getDirDetails to return valid details for our test directory
+            sandbox.stub(flowsImporter, 'getDirDetails').resolves(mockDirDetails)
+            Select.default.resolves(mockDirDetails)
+
+            const result = await flowsImporter.askImportDirectory([testFlowsDir])
+
+            result.should.deepEqual(mockDirDetails)
+            Select.default.calledOnce.should.be.true()
+        })
+
+        it('should prompt for custom path if user selects custom option', async function () {
+            sandbox.stub(flowsImporter, 'getDirDetails').resolves({
+                valid: true,
+                userDir: testFlowsDir,
+                flowFiles: [{ name: 'flows.json' }]
+            })
+
+            Select.default.resolves(-2) // CUSTOM option
+            Input.default.resolves(testFlowsDir)
+            Confirm.default.resolves(true)
+
+            const result = await flowsImporter.askImportDirectory([])
+
+            Input.default.calledOnce.should.be.true()
+            result.should.have.property('valid', true)
+            result.should.have.property('userDir', testFlowsDir)
+        })
+
+        it('should prompt with confirm dialog if no suggested dirs are provided', async function () {
+            Confirm.default.resolves(false) // No to "Import existing Node-RED flows?"
+
+            const result = await flowsImporter.askImportDirectory([])
+
+            Confirm.default.calledOnce.should.be.true()
+            result.should.have.property('skip', true)
+        })
+
+        it('should return skip result if user cancels custom path entry', async function () {
+            Confirm.default.resolves(true) // Yes to "Import existing Node-RED flows?"
+            Input.default.resolves('') // then skip
+
+            // note, because we are not providing any suggested dirs, the choice is auto skipped
+            // and user is simply asked to confirm "Import existing Node-RED flows?"
+
+            const result = await flowsImporter.askImportDirectory([])
+
+            result.should.be.false() // Skip import
+        })
+    })
+
+    describe('flowImport', function () {
+        it('should return null if user skips import', async function () {
+            sandbox.stub(flowsImporter, 'askImportDirectory').resolves({ skip: true })
+
+            const result = await flowsImporter.flowImport([testFlowsDir])
+
+            should(result).be.null()
+        })
+
+        it('should return null if user does not select a flows file', async function () {
+            sandbox.stub(flowsImporter, 'askImportDirectory').resolves({
+                valid: true,
+                userDir: testFlowsDir,
+                flowFiles: [{ name: 'flows.json' }]
+            })
+            sandbox.stub(flowsImporter, 'askSelectFlowsFile').resolves(false)
+
+            const result = await flowsImporter.flowImport([testFlowsDir])
+
+            should(result).be.null()
+        })
+
+        it('should import flows, credentials and package data', async function () {
+            // Create settings.js with credentialSecret
+            const settingsJs = path.join(testFlowsDir, 'settings.js')
+            await fs.writeFile(settingsJs, 'module.exports = { credentialSecret: "secret123" }')
+
+            // Create .config.runtime.json
+            const configRuntime = path.join(testFlowsDir, '.config.runtime.json')
+            await fs.writeFile(configRuntime, JSON.stringify({ _credentialSecret: 'configSecret' }))
+
+            const mockSelectedFlows = {
+                isFlowsFile: true,
+                userDir: testFlowsDir,
+                name: 'flows.json',
+                flowsFile: mockFlowsFile,
+                credsFile: mockCredsFile,
+                flows: mockFlows
+            }
+
+            sandbox.stub(flowsImporter, 'askImportDirectory').resolves({
+                valid: true,
+                userDir: testFlowsDir,
+                flowFiles: [mockSelectedFlows]
+            })
+
+            sandbox.stub(flowsImporter, 'askSelectFlowsFile').resolves(mockSelectedFlows)
+            sandbox.stub(utils, 'loadAndParseJsonFile').callsFake(filePath => {
+                if (filePath.includes('.config.runtime.json')) {
+                    return { _credentialSecret: 'configSecret' }
+                } else if (filePath.includes('settings.json')) {
+                    return null
+                }
+                return null
+            })
+
+            sandbox.stub(utils, 'extractKeyValueFromJsContent').returns('secret123')
+            sandbox.stub(utils, 'getPackageData').returns(mockPackageData)
+
+            const result = await flowsImporter.flowImport([testFlowsDir])
+
+            should(result).not.be.null()
+            result.should.have.property('flows').and.be.an.Array()
+            result.should.have.property('credentials').and.be.an.Object()
+            result.should.have.property('credentialSecret', 'configSecret') // Should get from .config.runtime.json first
+            result.should.have.property('package').and.be.an.Object()
+        })
+
+        it('should get credential secret from settings.json', async function () {
+            // Create settings.json with credentialSecret
+            const settingsJson = path.join(testFlowsDir, 'settings.json')
+            await fs.writeFile(settingsJson, JSON.stringify({ credentialSecret: 'settingsJsonSecret' }))
+            // Create settings.js with credentialSecret too (but it should be ignored)
+            const settingsJs = path.join(testFlowsDir, 'settings.js')
+            await fs.writeFile(settingsJs, 'module.exports = { credentialSecret: "settingsJsSecret" }')
+
+            const mockSelectedFlows = {
+                isFlowsFile: true,
+                userDir: testFlowsDir,
+                name: 'flows.json',
+                flowsFile: mockFlowsFile,
+                credsFile: mockCredsFile,
+                flows: mockFlows
+            }
+
+            sandbox.stub(flowsImporter, 'askImportDirectory').resolves({
+                valid: true,
+                userDir: testFlowsDir,
+                flowFiles: [mockSelectedFlows]
+            })
+
+            sandbox.stub(flowsImporter, 'askSelectFlowsFile').resolves(mockSelectedFlows)
+            sandbox.stub(utils, 'loadAndParseJsonFile').callsFake(filePath => {
+                if (filePath.includes('.config.runtime.json')) {
+                    return null // No runtime config
+                } else if (filePath.includes('settings.json')) {
+                    return { credentialSecret: 'settingsJsonSecret' }
+                }
+                return null
+            })
+
+            sandbox.stub(utils, 'getPackageData').returns(mockPackageData)
+            sandbox.spy(utils, 'extractKeyValueFromJsContent')
+
+            const result = await flowsImporter.flowImport([testFlowsDir])
+            utils.loadAndParseJsonFile.calledTwice.should.be.true() // settings.json and .config.runtime.json
+            utils.extractKeyValueFromJsContent.called.should.be.false() // not called because settings.json is used
+            result.should.have.property('credentialSecret', 'settingsJsonSecret') // Should get from settings.json
+        })
+
+        it('should get credential secret from settings.js', async function () {
+            // Create settings.js with credentialSecret
+            const settingsJs = path.join(testFlowsDir, 'settings.js')
+            await fs.writeFile(settingsJs, 'module.exports = { credentialSecret: "settingsJsSecret" }')
+
+            const mockSelectedFlows = {
+                isFlowsFile: true,
+                userDir: testFlowsDir,
+                name: 'flows.json',
+                flowsFile: mockFlowsFile,
+                credsFile: mockCredsFile,
+                flows: mockFlows
+            }
+
+            sandbox.stub(flowsImporter, 'askImportDirectory').resolves({
+                valid: true,
+                userDir: testFlowsDir,
+                flowFiles: [mockSelectedFlows]
+            })
+
+            sandbox.stub(flowsImporter, 'askSelectFlowsFile').resolves(mockSelectedFlows)
+            sandbox.stub(utils, 'loadAndParseJsonFile').callsFake(filePath => {
+                return null // No runtime config or settings.json
+            })
+
+            sandbox.stub(utils, 'extractKeyValueFromJsContent').returns('settingsJsSecret')
+            sandbox.stub(utils, 'getPackageData').returns(mockPackageData)
+
+            const result = await flowsImporter.flowImport([testFlowsDir])
+            utils.loadAndParseJsonFile.calledTwice.should.be.true() // settings.js and .config.runtime.json
+            utils.extractKeyValueFromJsContent.calledOnce.should.be.true()
+            result.should.have.property('credentialSecret', 'settingsJsSecret') // Should get from settings.js
+        })
+
+        it('should handle missing credentials file', async function () {
+            // Delete credentials file
+            await fs.unlink(mockCredsFile)
+
+            const mockSelectedFlows = {
+                isFlowsFile: true,
+                userDir: testFlowsDir,
+                name: 'flows.json',
+                flowsFile: mockFlowsFile,
+                credsFile: null, // No creds file
+                flows: mockFlows
+            }
+
+            sandbox.stub(flowsImporter, 'askImportDirectory').resolves({
+                valid: true,
+                userDir: testFlowsDir,
+                flowFiles: [mockSelectedFlows]
+            })
+
+            sandbox.stub(flowsImporter, 'askSelectFlowsFile').resolves(mockSelectedFlows)
+            sandbox.stub(utils, 'getPackageData').returns(mockPackageData)
+
+            const result = await flowsImporter.flowImport([testFlowsDir])
+
+            result.should.have.property('credentials').and.be.empty()
+        })
+    })
+})

--- a/test/unit/lib/launcher_spec.js
+++ b/test/unit/lib/launcher_spec.js
@@ -47,7 +47,15 @@ describe('Launcher', function () {
     })
 
     afterEach(async function () {
-        await fs.rm(config.dir, { recursive: true, force: true })
+        try {
+            // Force removal of the directory and its contents
+            await fs.rm(config.dir, { recursive: true, force: true })
+        } catch (err) {
+            // If the standard rm fails, try again after a short delay (improves occasional fails on Windows)
+            console.debug('Directory removal failed, trying again in a moment')
+            await new Promise(resolve => setTimeout(resolve, 100))
+            await fs.rm(config.dir, { recursive: true, force: true })
+        }
         sinon.restore()
     })
 

--- a/test/unit/lib/util_spec.js
+++ b/test/unit/lib/util_spec.js
@@ -385,6 +385,15 @@ describe('utils', function () {
             const result = utils.extractKeyValueFromJsContent(jsContent, 'credentialSecret')
             should(result).be.null()
         })
+        it('should return null if the key is /* commented */ out', function () {
+            const jsContent = `module.exports = {
+                /* A comment */
+                /* credentialSecret: 'my-secret', */
+                anotherKey: 'another-value'
+            }`
+            const result = utils.extractKeyValueFromJsContent(jsContent, 'credentialSecret')
+            should(result).be.null()
+        })
     })
 
     describe('loadAndParseJsonFile', function () {

--- a/test/unit/lib/util_spec.js
+++ b/test/unit/lib/util_spec.js
@@ -352,29 +352,36 @@ describe('utils', function () {
 
     describe('extractKeyValueFromJsContent', function () {
         it('should extract the correct value for a given key', function () {
-            const jsContent = `
+            const jsContent = `module.exports = {
                 /* A comment */
                 credentialSecret: 'my-secret',
                 anotherKey: 'another-value'
-            `
+            }`
+            const result = utils.extractKeyValueFromJsContent(jsContent, 'credentialSecret')
+            result.should.equal('my-secret')
+        })
+
+        // Test for a minified JS content - currently not supported
+        it.skip('should extract the correct value for a given key in a minified settings file', function () {
+            const jsContent = "module.exports={/* A comment */ credentialSecret: 'my-secret'}"
             const result = utils.extractKeyValueFromJsContent(jsContent, 'credentialSecret')
             result.should.equal('my-secret')
         })
 
         it('should return null if the key is not found', function () {
-            const jsContent = `
+            const jsContent = `module.exports = {
                 /* A comment */
                 anotherKey: 'another-value'
-            `
+        }`
             const result = utils.extractKeyValueFromJsContent(jsContent, 'missingKey')
             should(result).be.null()
         })
-        it('should return null if the key is commented out', function () {
-            const jsContent = `
+        it('should return null if the key is // commented out', function () {
+            const jsContent = `module.exports = {
                 /* A comment */
                 // credentialSecret: 'my-secret',
                 anotherKey: 'another-value'
-            `
+            }`
             const result = utils.extractKeyValueFromJsContent(jsContent, 'credentialSecret')
             should(result).be.null()
         })

--- a/test/unit/lib/util_spec.js
+++ b/test/unit/lib/util_spec.js
@@ -1,5 +1,6 @@
 const should = require('should') // eslint-disable-line
 const utils = require('../../../lib/utils.js')
+const sinon = require('sinon') // Add sinon for stubbing
 
 /*
     Ensure utils used throughout agent are tested
@@ -9,6 +10,14 @@ const utils = require('../../../lib/utils.js')
     * hasProperty
 */
 describe('utils', function () {
+    beforeEach(function () {
+        this.sandbox = sinon.createSandbox()
+    })
+
+    afterEach(function () {
+        this.sandbox.restore()
+    })
+
     describe('isObject', function () {
         it('should return true for objects', function () {
             utils.isObject({}).should.be.true()
@@ -317,6 +326,94 @@ describe('utils', function () {
             process.env.https_proxy = 'http://proxy:8081'
             const agent = utils.getHTTPProxyAgent('https://127.0.0.1:3000', { timeout: 2345 })
             agent.https.connectOpts.should.have.property('timeout', 2345)
+        })
+    })
+
+    describe('getPackageData', function () {
+        it('should correctly parse package data', function () {
+            const mockPackageJson = JSON.stringify({
+                dependencies: { 'module-a': '^1.0.0' },
+                version: '1.0.0',
+                name: 'test-package',
+                description: 'A test package'
+            })
+            const fs = require('fs')
+            const readFileSyncStub = this.sandbox.stub(fs, 'readFileSync').returns(mockPackageJson)
+
+            const result = utils.getPackageData('mock/path/package.json')
+            result.should.have.property('modules').eql({ 'module-a': '^1.0.0' })
+            result.should.have.property('version', '1.0.0')
+            result.should.have.property('name', 'test-package')
+            result.should.have.property('description', 'A test package')
+
+            readFileSyncStub.calledOnceWith('mock/path/package.json').should.be.true()
+        })
+    })
+
+    describe('extractKeyValueFromJsContent', function () {
+        it('should extract the correct value for a given key', function () {
+            const jsContent = `
+                /* A comment */
+                credentialSecret: 'my-secret',
+                anotherKey: 'another-value'
+            `
+            const result = utils.extractKeyValueFromJsContent(jsContent, 'credentialSecret')
+            result.should.equal('my-secret')
+        })
+
+        it('should return null if the key is not found', function () {
+            const jsContent = `
+                /* A comment */
+                anotherKey: 'another-value'
+            `
+            const result = utils.extractKeyValueFromJsContent(jsContent, 'missingKey')
+            should(result).be.null()
+        })
+        it('should return null if the key is commented out', function () {
+            const jsContent = `
+                /* A comment */
+                // credentialSecret: 'my-secret',
+                anotherKey: 'another-value'
+            `
+            const result = utils.extractKeyValueFromJsContent(jsContent, 'credentialSecret')
+            should(result).be.null()
+        })
+    })
+
+    describe('loadAndParseJsonFile', function () {
+        it('should correctly parse a valid JSON file', function () {
+            const mockJsonContent = JSON.stringify({ key: 'value' })
+            const fs = require('fs')
+            const readFileSyncStub = this.sandbox.stub(fs, 'readFileSync').returns(mockJsonContent)
+            const existsSyncStub = this.sandbox.stub(fs, 'existsSync').returns(true)
+
+            const result = utils.loadAndParseJsonFile('mock/path/file.json')
+            result.should.eql({ key: 'value' })
+
+            existsSyncStub.calledOnceWith('mock/path/file.json').should.be.true()
+            readFileSyncStub.calledOnceWith('mock/path/file.json', 'utf8').should.be.true()
+        })
+
+        it('should return null if the file does not exist', function () {
+            const fs = require('fs')
+            const existsSyncStub = this.sandbox.stub(fs, 'existsSync').returns(false)
+
+            const result = utils.loadAndParseJsonFile('mock/path/file.json')
+            should(result).be.null()
+
+            existsSyncStub.calledOnceWith('mock/path/file.json').should.be.true()
+        })
+
+        it('should return null if the file contains invalid JSON', function () {
+            const fs = require('fs')
+            const readFileSyncStub = this.sandbox.stub(fs, 'readFileSync').throws(new Error('Invalid JSON'))
+            const existsSyncStub = this.sandbox.stub(fs, 'existsSync').returns(true)
+
+            const result = utils.loadAndParseJsonFile('mock/path/file.json')
+            should(result).be.null()
+
+            existsSyncStub.calledOnceWith('mock/path/file.json').should.be.true()
+            readFileSyncStub.calledOnceWith('mock/path/file.json', 'utf8').should.be.true()
         })
     })
 })


### PR DESCRIPTION
## Description

### IMPORTANT:
* Do not merge until FF PR [5473](https://github.com/FlowFuse/flowfuse/pull/5473) is approved/merged
* Depends on FF being > 2.15.0 as a way to identify backend supports upload

### TLDR
Adds prompts for importing user flows after device is registered using OTC setup


### Details:
* Adds "@inquirer/input": "^4.1.9" and "@inquirer/select": "^4.2.0"
   * This is from the same set that we currently use for Confirmations (@inquirer/confrim)
* Adds CLI flag `otc-dont-import` to permit automations to skip prompt
* Adds file `lib/cli/flowsImporter.js` that handles the prompting (simplifies integration in `index.js`)
* Refactors logic from `launcher.readPackage` to a utility function `utils.getPackageData` since it will be used by `flowsImporter`
* Adds `loadAndParseJsonFile` and `extractKeyValueFromJsContent` utility functions (full unit tests included)
* Also includes a fix in `test/unit/lib/launcher_spec.js` for flaky test on windows.
* If the device is NOT owned by an application the import step is skipped (as per issue MVP)
* There is a level of sanity checks to avoid uploading duff flows (package exists, flows are an array of objects)
* Flows `credentialSecret` is dug out of the files in the following order:
   * `.config.runtime.json` file
   * If not found, it looks in `settings.json` (for FF device files import)
   * If not found, it scrapes `settings.js`
   * if no `credentialSecret` is found, we set the `credentials` to an empty object and proceed regardless
* Modules are imported from `package.json` but with following caveat:
    * If they are local installed modules (e.g. the module version starts with `file:` instead of a version "^1.0.1" value, it is set to "*"
* The imported snapshot is sent and FFC side sets it as the target (so that upon launching the device, it receives this uploaded snapshot)
    * This is implicit (we don't ask the user, we assume they want to use the imported snapshot)

### Tests:

#### `test/unit/lib/cli/flowsImporter_spec.js`
```
  Flows Importer
    getFlowsFileDetails
      ✔ should identify a valid Node-RED flows file
      ✔ should reject an invalid JSON file
      ✔ should reject a JSON file that is not a Node-RED flows file
    getFlowFiles
      ✔ should find Node-RED flows files in a directory
      ✔ should ignore files that are not flows files
      ✔ should return empty array for invalid directory
      ✔ should return empty array if package.json does not exist
    getDirDetails
      ✔ should return valid directory details
      ✔ should return invalid details for directory without flows
    askSelectFlowsFile
      ✔ should prompt user to select a flows file
      ✔ should return false if user selects skip
      ✔ should return false if no flow files are provided
      ✔ should prompt user to select a flows file
    askImportDirectory
      ✔ should return directory details if user selects a suggested directory
      ✔ should prompt for custom path if user selects custom option
      ✔ should prompt with confirm dialog if no suggested dirs are provided
      ✔ should return skip result if user cancels custom path entry
    flowImport
      ✔ should return null if user skips import
      ✔ should return null if user does not select a flows file
      ✔ should import flows, credentials and package data
      ✔ should get credential secret from settings.json
      ✔ should get credential secret from settings.js
      ✔ should handle missing credentials file
```

#### `test/unit/lib/util_spec.js`
```
  utils
    getPackageData
      ✔ should correctly parse package data
    extractKeyValueFromJsContent
      ✔ should extract the correct value for a given key
      - should extract the correct value for a given key in a minified settings file
      ✔ should return null if the key is not found
      ✔ should return null if the key is // commented out
      ✔ should return null if the key is /* commented */ out
    loadAndParseJsonFile
      ✔ should correctly parse a valid JSON file
      ✔ should return null if the file does not exist
      ✔ should return null if the file contains invalid JSON
```


## Related Issue(s)

Owner: #387 
Parent:  https://github.com/FlowFuse/flowfuse/issues/5366


## Checklist



<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

