### PR TITLE
Fix ffVersion parsing to handle version suffixes properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,9 @@ Please ensure the parent directory is writable, or set a different path with -d`
             print(runCommandInfo.join(' '), ' ')
             if (!options.otcNoImport) {
                 // Support for importing flows during initial state check-in was added after 2.16.0.
-                const ffVersion = deviceSettings.meta?.ffVersion?.replace(/[^0-9.]/g, '') || '0.0.0' // Strip suffixes like -beta.1
+                // Use semver.coerce to validate the ffVersion. This will, by default, strip off suffixes to ensure
+                // a clean x.y.z comparison.
+                const ffVersion = semver.coerce(deviceSettings.meta?.ffVersion || '0.0.0') // Strip suffixes like -beta.1
                 const ffSupportsImport = (ffVersion && semver.gt(ffVersion, '2.16.0'))
 
                 if (ffSupportsImport) {


### PR DESCRIPTION
The code that checks the received `ffVersion` value to see if we can offer the import of flows was not formatting the value correctly.

When running against production, it was receiving a version of `2.17.1-999a684-202505080957.0`. The code was converting that to `2.17.1999684202505080957.0` - which is an invalid semver string and causing an error.

This PR fixes it by using `semver.coerce` to parse the version string. By default coerce will strip off the suffix.

Strictly speaking, it is not necessary to strip off the suffix - semver does the right thing as long as the version string is well formatted.

