### PR TITLE
Only use local HOME env var if not passed from settings

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -475,9 +475,13 @@ class Launcher {
 
         // should set HOME env var
         if (process.platform === 'win32') {
-            env.UserProfile = process.env.UserProfile
+            if (process.env.UserProfile && !env.UserProfile) {
+                env.UserProfile = process.env.UserProfile
+            }
         } else {
-            env.HOME = process.env.HOME
+            if (process.env.HOME && !env.HOME) {
+               env.HOME = process.env.HOME
+            }
         }
 
         // Use local timezone if set, else use one from snapshot settings


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Customer running in OpenShift with no HOME env var set in the container.

They tried to set it in the FlowFuse device settings, but this code overwrites with local even if not set.

This only uses the local version if

1. it's present
2. it's not come from settings

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

