### PR TITLE
Simplified flow file import browsing in terminal

### DIFF
--- a/lib/cli/fileSelector/consts.js
+++ b/lib/cli/fileSelector/consts.js
@@ -1,0 +1,11 @@
+/** ANSI escape code to hide the cursor. */
+const ANSI_HIDE_CURSOR = '\x1B[?25l'
+
+/** Possible prompt statuses. */
+const Status = {
+    Idle: 'idle',
+    Done: 'done',
+    Canceled: 'canceled'
+}
+
+module.exports = { ANSI_HIDE_CURSOR, Status }

--- a/lib/cli/fileSelector/index.js
+++ b/lib/cli/fileSelector/index.js
@@ -1,0 +1,251 @@
+// This component and its adjacent files are a large rework of the MIT licenced @inquirer-file-selector
+// (https://www.npmjs.com/package/inquirer-file-selector)
+// It was the closest match to the functionality we needed, but did not have some of the features we wanted like:
+// not showing parent .. dir, unfavourable navigation key bindings (& no means of changing them), no means of
+// dynamically setting dir/file descriptions, and it would crash on certain directories (permission issues #94), etc.
+// Below is a copy of the original license
+
+/*
+Copyright 2024 Brian Fernandez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+'use strict'
+const path = require('node:path')
+const {
+    createPrompt,
+    makeTheme,
+    useKeypress,
+    useMemo,
+    usePagination,
+    usePrefix,
+    useState
+} = require('@inquirer/core')
+const { ANSI_HIDE_CURSOR, Status } = require('./consts')
+const { baseTheme } = require('./theme')
+const {
+    createRawItem,
+    ensurePathSeparator,
+    readRawItems,
+    sortRawItems,
+    stripInternalProps
+} = require('./utils/item')
+const {
+    isBackspaceKey,
+    isDownKey,
+    isEnterKey,
+    isEscapeKey,
+    isSpaceKey,
+    isUpKey,
+    isLeftArrowKey,
+    isRightArrowKey,
+    isPageUp,
+    isPageDown
+} = require('./utils/key')
+
+/**
+ * Creates a file or directory selector prompt.
+ * @param {Object} config - Configuration for the prompt.
+ * @param {string} [config.message] - Message to display in the prompt.
+ * @param {string} [config.basePath='.'] - Path to start the selection from.
+ * @param {'file'|'directory'} [config.mode='file'] - Mode of selection, either 'file' or 'directory'.
+ * @param {number} [config.pageSize=10] - Number of items to display per page.
+ * @param {boolean} [config.loop=false] - Whether to loop through items.
+ * @param {function} [config.filter] - Function to filter items.
+ * @param {function} [config.fileDescriptionHook] - Hook to format file descriptions.
+ * @param {function} [config.directoryDescriptionHook] - Hook to format directory descriptions.
+ * @param {boolean} [config.showExcluded=false] - Whether to show excluded items.
+ * @param {boolean} [config.allowCancel=false] - Whether to allow canceling the prompt.
+ * @param {string} [config.cancelText='Canceled.'] - Text to display when canceled.
+ * @param {string} [config.emptyText='Directory is empty.'] - Text to display when the directory is empty.
+ */
+function fileSelector (config) {
+    return createPrompt((config, done) => {
+        const {
+            mode = 'file',
+            message = 'Select a file',
+            pageSize = 10,
+            loop = false,
+            filter = () => true,
+            fileDescriptionHook = null,
+            directoryDescriptionHook = null,
+            showExcluded = false,
+            allowCancel = false,
+            cancelText = 'Canceled.',
+            emptyText = 'Directory is empty.'
+        } = config
+
+        const [status, setStatus] = useState(Status.Idle)
+        const theme = makeTheme(baseTheme, config.theme)
+        const prefix = usePrefix({ status, theme })
+
+        const [currentDir, setCurrentDir] = useState(
+            path.resolve(process.cwd(), config.basePath || '.')
+        )
+
+        const items = useMemo(() => {
+            const rawItems = readRawItems(currentDir)
+                .map(rawItem => {
+                    const strippedItem = stripInternalProps(rawItem)
+                    const isDisabled = !filter(strippedItem)
+                    return { ...rawItem, isDisabled }
+                })
+            const filteredItems = []
+            filteredItems.push(...rawItems.filter(rawItem => showExcluded || !rawItem.isDisabled))
+            sortRawItems(filteredItems)
+
+            const parentPath = path.join(currentDir, '..')
+            const hasParent = parentPath !== currentDir
+            const parent = hasParent ? createRawItem(parentPath) : null
+            if (parent) {
+                parent.displayName = ensurePathSeparator('..')
+                parent.isDisabled = false
+                parent.isParentDirectory = true // Mark as parent directory
+            }
+
+            if (parent) {
+                filteredItems.unshift(parent)
+            }
+
+            if (mode !== 'file') {
+                const cwd = createRawItem(currentDir)
+                cwd.displayName = ensurePathSeparator('.')
+                cwd.isCurrentDirectory = true // Mark as current directory
+                filteredItems.unshift(cwd)
+            }
+
+            return filteredItems
+        }, [currentDir])
+
+        const bounds = useMemo(() => {
+            const first = items.findIndex(rawItem => !rawItem.isDisabled)
+            const last = items.findLastIndex(rawItem => !rawItem.isDisabled)
+
+            if (first === -1) {
+                return { first: 0, last: 0 }
+            }
+
+            return { first, last }
+        }, [items])
+
+        const [active, setActive] = useState(bounds.first)
+        const activeItem = items[active]
+
+        useKeypress((key, rl) => {
+            const enterSelectsDir = !activeItem.isDisabled && mode === 'directory' && activeItem?.isDirectory && !activeItem.isParentDirectory
+            const enterOpensDir = !activeItem.isDisabled && (
+                (mode === 'file' && activeItem?.isDirectory) ||
+                (mode === 'directory' && activeItem?.isDirectory && activeItem.isParentDirectory)
+            )
+            const enterSelectsFile = !activeItem.isDisabled && mode === 'file' && !activeItem?.isDirectory
+            const enterDoesNothing = activeItem?.isDisabled || (!enterSelectsDir && !enterOpensDir && !enterSelectsFile)
+            if (enterDoesNothing) {
+                return
+            }
+            if (activeItem && isEnterKey(key)) {
+                if (enterOpensDir) {
+                    setCurrentDir(activeItem.path)
+                    setActive(bounds.first)
+                } else if (enterSelectsDir || enterSelectsFile) {
+                    const strippedItem = stripInternalProps(activeItem)
+                    setStatus(Status.Done)
+                    done(strippedItem)
+                }
+            } else if (activeItem?.isDirectory && ((enterOpensDir && isEnterKey(key)) || isSpaceKey(key) || isRightArrowKey(key))) {
+                setCurrentDir(activeItem.path)
+                setActive(bounds.first)
+            } else if (isUpKey(key) || isDownKey(key)) {
+                rl.clearLine(0)
+
+                if (
+                    loop ||
+                    (isUpKey(key) && active !== bounds.first) ||
+                    (isDownKey(key) && active !== bounds.last)
+                ) {
+                    const offset = isUpKey(key) ? -1 : 1
+                    let next = active
+
+                    do {
+                        next = (next + offset + items.length) % items.length
+                    } while (items[next].isDisabled)
+
+                    setActive(next)
+                }
+            } else if (isPageDown(key)) {
+                rl.clearLine(0)
+                let next = active + (pageSize || 10)
+                if (next >= items.length) {
+                    next = items.length - 1
+                }
+
+                while (next > active && items[next].isDisabled) {
+                    next--
+                    // guard against going below the first item
+                    if (next < bounds.first) {
+                        next = bounds.first
+                        break
+                    }
+                }
+                if (next !== active) {
+                    setActive(next)
+                }
+            } else if (isPageUp(key)) {
+                rl.clearLine(0)
+                let next = active - (pageSize || 10)
+                if (next < 0) {
+                    next = 0
+                }
+                while (next < active && items[next].isDisabled) {
+                    next++
+                    // guard against going above the last item
+                    if (next > bounds.last) {
+                        next = bounds.last
+                        break
+                    }
+                }
+                if (next !== active) {
+                    setActive(next)
+                }
+            } else if (isBackspaceKey(key) || isLeftArrowKey(key)) {
+                setCurrentDir(path.resolve(currentDir, '..'))
+                setActive(bounds.first)
+            } else if (isEscapeKey(key) && allowCancel) {
+                setStatus(Status.Canceled)
+                done(null)
+            }
+        })
+
+        const page = usePagination({
+            items,
+            active,
+            renderItem: ({ item, index, isActive }) => {
+                const isCwd = item.path === currentDir
+                return theme.renderItem(item, { items, loop, index, isActive, isCwd, mode: config.mode, fileDescriptionHook, directoryDescriptionHook })
+            },
+            pageSize,
+            loop
+        })
+
+        const styledMessage = theme.style.message(message || `Select a ${mode}`, status)
+
+        if (status === Status.Canceled) {
+            return `${prefix} ${styledMessage} ${theme.style.cancelText(cancelText)}`
+        }
+
+        if (status === Status.Done) {
+            return `${prefix} ${styledMessage} ${theme.style.answer(activeItem.path)}`
+        }
+
+        const helpTop = theme.style.help(theme.help.top(allowCancel))
+        const header = theme.style.currentDir(ensurePathSeparator(currentDir))
+
+        return `${prefix} ${styledMessage} ${helpTop}\n${header}\n${!page.length ? theme.style.emptyText(emptyText) : page}${ANSI_HIDE_CURSOR}`
+    })(config)
+}
+
+module.exports = { fileSelector, Status }

--- a/lib/cli/fileSelector/theme.js
+++ b/lib/cli/fileSelector/theme.js
@@ -1,0 +1,93 @@
+const { default: figures } = require('@inquirer/figures')
+const { Chalk } = require('chalk')
+const chalk = new Chalk({ level: 3 })
+const baseTheme = {
+    prefix: {
+        idle: chalk.cyan('?'),
+        done: chalk.green(figures.tick),
+        canceled: chalk.red(figures.cross)
+    },
+    style: {
+        disabled: (linePrefix, text) =>
+            chalk.gray(`${linePrefix} ${chalk.strikethrough(text)}`),
+        active: (text) => chalk.cyanBright(text),
+        cancelText: (text) => chalk.red(text),
+        emptyText: (text) => chalk.red(text),
+        directory: (text) => chalk.yellowBright(text),
+        file: (text) => text,
+        currentDir: (text) => chalk.cyan(text),
+        message: (text, _status) => chalk.bold(text),
+        help: (text) => chalk.italic.dim.gray(text)
+    },
+    hierarchySymbols: {
+        branch: figures.lineUpDownRight + figures.line,
+        leaf: figures.lineUpRight + figures.line
+    },
+    help: {
+        top: (allowCancel, context) => {
+            if (context && context.mode === 'directory') {
+                return `(Use arrows ${figures.arrowUp} ${figures.arrowDown} to navigate, <enter> to select directory, <esc> to cancel)`
+            }
+            return `(Use arrows ${figures.arrowUp} ${figures.arrowDown} ${figures.arrowLeft} ${figures.arrowRight} to navigate${allowCancel ? ', <enter> to select file, <esc> to cancel' : ''})`
+        },
+        directory: (item, context) => {
+            const { isCwd, mode } = context
+            let helpText
+            if (isCwd) {
+                helpText = '(Press <enter> to select this directory)'
+            } else if (item.isParentDirectory && mode === 'directory') {
+                helpText = '(Press <enter> to navigate)'
+            } else {
+                const enterSelectsDir = item.isDirectory && mode === 'directory'
+                if (enterSelectsDir) {
+                    helpText = '(Press <enter> to select)'
+                } else {
+                    helpText = '(Press <enter> to navigate)'
+                }
+            }
+            return helpText
+        },
+        file: (item, context) => {
+            return '(Press <enter> to select)'
+        }
+    },
+    /**
+     * Render a file or directory item.
+     * @param {{ item: { displayName: string, isDirectory: boolean }, index:number, isActive:boolean }} item
+     * @param {{ items, loop, index:number, isActive:boolean, isCwd:boolean, mode: 'file|directory' }} context
+     * @returns
+     */
+    renderItem (item, context) {
+        const { fileDescriptionHook, directoryDescriptionHook } = context
+        const isLast = context.index === context.items.length - 1
+        const linePrefix =
+            isLast && !context.loop
+                ? this.hierarchySymbols.leaf
+                : this.hierarchySymbols.branch
+
+        if (item.isDisabled) {
+            return this.style.disabled(linePrefix, item.displayName)
+        }
+
+        const baseColor = item.isDirectory ? this.style.directory : this.style.file
+        const color = context.isActive ? this.style.active : baseColor
+        let line = color(`${linePrefix} ${item.displayName}`)
+
+        if (context.isActive) {
+            if (item.isDirectory) {
+                item.helpText = this.help.directory(item, context)
+                item.helpText = directoryDescriptionHook ? directoryDescriptionHook(item, context) : item.helpText
+            } else {
+                item.helpText = this.help.file(item, context)
+                item.helpText = fileDescriptionHook ? fileDescriptionHook(item, context) : item.helpText
+            }
+            if (item.helpText) {
+                line = `${line} ${this.style.help(item.helpText)}`
+            }
+        }
+
+        return line
+    }
+}
+
+module.exports = { baseTheme }

--- a/lib/cli/fileSelector/utils/item.js
+++ b/lib/cli/fileSelector/utils/item.js
@@ -1,0 +1,109 @@
+// eslint-disable-next-line no-unused-vars
+const { readdirSync, statSync, Stats } = require('node:fs')
+const { basename, join, sep, dirname } = require('node:path')
+
+/** Appends the system-specific path separator to the end of the path if missing. */
+function ensurePathSeparator (path) {
+    return path.endsWith(sep) ? path : `${path}${sep}`
+}
+
+/** Creates a `RawItem` from a given filesystem path. */
+function createRawItem (path) {
+    const name = basename(path)
+    const dir = dirname(path)
+    try {
+        /** @type {Stats} */
+        const stats = statSync(path)
+        const isDirectory = stats.isDirectory()
+        const displayName = isDirectory ? ensurePathSeparator(name) : name
+
+        return {
+            displayName,
+            name,
+            path,
+            dir,
+            size: stats.size,
+            createdMs: stats.birthtimeMs,
+            lastModifiedMs: stats.mtimeMs,
+            isDisabled: false,
+            isDirectory
+        }
+    } catch (error) {
+        // console.error(`Error reading path "${path}":`, error);
+        return {
+            displayName: name,
+            name,
+            path,
+            dir,
+            size: 0,
+            createdMs: 0,
+            lastModifiedMs: 0,
+            isDisabled: true,
+            isDirectory: false
+        }
+    }
+}
+
+/** Reads all entries in the directory and returns them as `RawItem[]`. */
+function readRawItems (path, mode = 'file') {
+    let dirRead = []
+    if (mode !== 'file' && mode !== 'directory') {
+        return dirRead
+    }
+    try {
+        dirRead = readdirSync(path)
+    } catch (_error) {
+        if (_error.code === 'ENOENT') {
+            console.log(`Directory "${path}" does not exist.`)
+            return []
+        }
+        if (_error.code === 'EPERM') {
+            console.log(`Permission denied to read directory "${path}".`)
+            return []
+        }
+        // console.log(`Error reading directory "${path}":`, _error);
+    }
+
+    const result = dirRead.map(fileName => {
+        const filePath = join(path, fileName)
+        return createRawItem(filePath)
+    })
+    return result
+}
+
+/**
+ * Sorts the given array of `RawItem`s by the following criteria:
+ * 1. Enabled items before disabled ones.
+ * 2. Directories before files.
+ * 3. Alphabetical order (by name) if priorities match.
+ *
+ * Mutates the original array.
+ * @param {RawItem[]} items - The array of `RawItem`s to sort.
+ * @returns {void}
+ */
+function sortRawItems (items) {
+    items.sort((a, b) => {
+        const aPriority = (a.isDisabled ? 2 : 0) + (a.isDirectory ? -1 : 0)
+        const bPriority = (b.isDisabled ? 2 : 0) + (b.isDirectory ? -1 : 0)
+
+        if (aPriority !== bPriority) {
+            return aPriority - bPriority
+        }
+
+        return a.name.localeCompare(b.name)
+    })
+}
+
+/** Removes internal-only properties (`displayName` and `isDisabled`) from a `RawItem`. */
+function stripInternalProps (raw) {
+    const { displayName, isDisabled, ...item } = raw
+    return item
+}
+
+module.exports = {
+    ensurePathSeparator,
+    createRawItem,
+    readRawItems,
+    sortRawItems,
+    stripInternalProps
+}

--- a/lib/cli/fileSelector/utils/key.js
+++ b/lib/cli/fileSelector/utils/key.js
@@ -1,0 +1,41 @@
+const {
+    isBackspaceKey,
+    isDownKey,
+    isEnterKey,
+    isSpaceKey,
+    isUpKey
+} = require('@inquirer/core')
+
+/** Check if the given key is the Escape key. */
+function isEscapeKey (key) {
+    return key.name === 'escape'
+}
+/** Check if the given key is the right Arrow. */
+function isRightArrowKey (key) {
+    return key.name === 'right'
+}
+/** Check if the given key is the left Arrow. */
+function isLeftArrowKey (key) {
+    return key.name === 'left'
+}
+
+function isPageDown (key) {
+    return key.name === 'pagedown'
+}
+
+function isPageUp (key) {
+    return key.name === 'pageup'
+}
+
+module.exports = {
+    isBackspaceKey,
+    isDownKey,
+    isEnterKey,
+    isSpaceKey,
+    isUpKey,
+    isEscapeKey,
+    isRightArrowKey,
+    isLeftArrowKey,
+    isPageUp,
+    isPageDown
+}

--- a/lib/cli/flowsImporter.js
+++ b/lib/cli/flowsImporter.js
@@ -1,27 +1,28 @@
 const { existsSync, statSync } = require('node:fs')
 const { promises: fsPromises } = require('node:fs')
+const fs = require('node:fs')
 const path = require('node:path')
 const utils = require('../utils')
+const { default: chalk } = require('chalk')
 const select = require('@inquirer/select').default
-const input = require('@inquirer/input').default
-const confirm = require('@inquirer/confirm').default
 const figures = require('@inquirer/figures').default
 const print = (message, /** @type {figures} */ figure = figures.info) => console.info(figure ?? figures.info, message)
+const fileSelector = require('./fileSelector/index.js').fileSelector
 
 const CHOICES = {
     SKIP: false, // skip import
-    CUSTOM: -2 // custom path
+    BROWSE: -2 // browse filesystem
 }
 
 /**
  * Asks the user if they want to import existing Node-RED flows from a directory.
- * If the user chooses to import, they can select from existing directories or enter a custom path.
+ * If the user chooses to import, they can select from existing directories or browse.
  * If the user chooses to skip, the function returns false.
- * If the user chooses a custom path, the function returns the path as a string.
+ * If the user chooses a custom path, the function returns an object containing the path and other details.
  * @param {*} [options] - Options object containing the `dir` to check for existing flows of an existing agent directory
  * @returns {Promise<{skip:Boolean,valid:Boolean,dir:string,flowFiles:Array}>}
  */
-async function askImportDirectory (suggestedDirs) {
+async function askImport (suggestedDirs) {
     // get details for each suggested directory
     let suggestedDirDetails = []
     if (suggestedDirs?.length > 0) {
@@ -32,63 +33,36 @@ async function askImportDirectory (suggestedDirs) {
             }
             return null
         }))
-        suggestedDirDetails = suggestedDirDetails.filter(dir => dir !== null)
+        suggestedDirDetails = suggestedDirDetails.filter(dir => dir !== null && dir.valid)
     }
 
     let choice = CHOICES.SKIP
-    if (suggestedDirDetails.length > 0) {
-        const choices = []
-        choices.push({ name: 'Skip import', value: CHOICES.SKIP, description: 'Press <enter> to skip import' })
-        suggestedDirDetails.forEach(dirDetails => {
-            const flowsCount = dirDetails.flowFiles.length
-            choices.push({ name: dirDetails.userDir, value: dirDetails, description: `Press <enter> to select this directory (contains ${flowsCount} Node-RED flows file${flowsCount > 1 ? 's' : ''})` })
-        })
-        choices.push({ name: 'Custom path...', value: CHOICES.CUSTOM, description: 'Manually enter the path to a Node-RED directory' })
-        choice = await select({
-            message: 'Import existing Node-RED flows?',
-            choices,
-            pageSize: 10,
-            instructions: { navigation: 'Use arrow keys to navigate, press <enter> to confirm' }
-        })
-    } else {
-        const answer = await confirm({
-            message: 'Import existing Node-RED flows?',
-            default: false
-        })
-
-        if (answer) {
-            choice = CHOICES.CUSTOM
-        }
-    }
-    let details = null
-    if (choice === CHOICES.CUSTOM) {
-        const customPath = await input({
-            message: 'Enter the path to your Node-RED directory (leave blank to cancel):',
-            validate: async (input) => {
-                details = null
-                if (!input.trim()) {
-                    return true
-                }
-                if (!existsSync(input)) {
-                    return 'Path does not exist.'
-                }
-                if (!statSync(input).isDirectory()) {
-                    return 'Path is not a directory.'
-                }
-                // check to see if any of the files in the directory are Node-RED flows files
-                details = await getDirDetails(input)
-                if (!details?.valid) {
-                    return `'${input}' does not contain any Node-RED flows files.`
-                }
-                return true
-            }
-        })
-        if (customPath.trim() === '') {
+    const choices = []
+    choices.push({ name: 'Skip import', value: CHOICES.SKIP, description: 'Press <enter> to skip import' })
+    suggestedDirDetails.forEach(dirDetails => {
+        const flowsCount = dirDetails.flowFiles.length
+        choices.push({ name: `Select a flow from "${dirDetails.userDir}"...`, value: dirDetails, description: `Press <enter> to browse this directory (contains ${flowsCount} Node-RED flows file${flowsCount > 1 ? 's' : ''})` })
+    })
+    choices.push({ name: 'Browse filesystem for flows...', value: CHOICES.BROWSE, description: 'Press <enter> to browse the filesystem for Node-RED flows files' })
+    choice = await select({
+        message: 'Import existing Node-RED flows?',
+        choices,
+        pageSize: 10,
+        instructions: { navigation: chalk.gray('Use arrow keys to select an option, press <enter> to confirm') }
+    })
+    const dirChosen = suggestedDirDetails.find(dir => dir.userDir === choice || dir === choice)
+    if (choice === CHOICES.BROWSE || dirChosen) {
+        const choice = await askBrowseForFlowFile(dirChosen ? dirChosen.userDir : null)
+        if (!choice || choice === 'canceled') {
             return CHOICES.SKIP
         }
-        if (customPath && !details) {
-            // tests do not cause the validate function to be called, so we need to update the details here
-            details = await getDirDetails(customPath)
+        if (!choice.path?.trim()) {
+            return CHOICES.SKIP
+        }
+        const details = {
+            ...choice,
+            valid: true,
+            packageFile: path.join(choice.dir, 'package.json')
         }
         return details
     }
@@ -101,50 +75,86 @@ async function askImportDirectory (suggestedDirs) {
     return choice
 }
 
-/**
- * Asks the user to select from the supplied list.
- * @param {Array<{isFlowsFile:Boolean,name:string,flowsFile:string,credsFile:string,description:string}>} flowFiles - The array of flow details
- * @returns {Promise<{isFlowsFile:Boolean,name:string,flowsFile:string,credsFile:string,description:string}>}
- */
-async function askSelectFlowsFile (flowFiles) {
-    if (!flowFiles?.length) {
-        return false
-    }
-
-    const choices = flowFiles.map(e => ({ name: e.name, value: e, description: e.description }))
-    choices.unshift({ name: 'Skip import', value: false, description: 'Press <enter> to skip import' })
-    let defaultChoice = choices[1].value
-    if (flowFiles.length > 1) {
-        defaultChoice = flowFiles.find(e => e.name === 'flows.json') || defaultChoice
-    }
-    const choice = await select({
-        message: 'Select a flows file:',
-        choices,
+async function askBrowseForFlowFile (startDir) {
+    const basePath = startDir || process.cwd()
+    const itemInfo = {}
+    const selectedOption = await fileSelector({
+        mode: 'file',
+        message: 'Select a flow file',
+        basePath,
+        allowCancel: true,
         pageSize: 10,
-        default: defaultChoice,
-        instructions: { navigation: 'Use arrow keys to navigate, press <enter> to confirm' }
+        loop: false,
+        filter: (item) => {
+            // return all items that are directories or valid Node-RED flow files
+            if (item?.isDirectory) {
+                return true
+            }
+            if (!item?.name || !item.name.endsWith('.json')) {
+                return false
+            }
+            try {
+                const flowsFileDetails = getFlowsFileDetails(path.dirname(item.path), path.basename(item.path))
+                itemInfo[item.path] = flowsFileDetails
+                return flowsFileDetails?.isFlowsFile
+            } catch (error) {
+                return false
+            }
+        },
+        fileDescriptionHook: (item, _context) => {
+            if (!item || !item.path) {
+                return 'No details available for this item'
+            }
+            const lastModifiedDate = new Date(item.lastModifiedMs).toLocaleString().replace(', ', ' ')
+            const sizeInKB = (item.size / 1024).toFixed(2)
+            let sizeString = `, ${sizeInKB} KB`
+            if (sizeInKB > 1024) {
+                sizeString = `, ${(sizeInKB / 1024).toFixed(2)} MB`
+            }
+            const itemDetails = itemInfo[item.path]
+            let itemDetailsString = ''
+            if (itemDetails) {
+                const sb = []
+                sb.push(`, ${itemDetails.tabCount} Tab${itemDetails.tabCount === 1 ? '' : 's'}`)
+                if (itemDetails.subflowCount > 0) {
+                    sb.push(`, ${itemDetails.subflowCount} Subflow${itemDetails.subflowCount === 1 ? '' : 's'}`)
+                }
+                sb.push(`, ${itemDetails.nodeCount}${itemDetails.nodeCount === 1 ? ' Node' : ' Nodes'}`)
+                itemDetailsString = sb.join('')
+            }
+            return `Last Modified ${lastModifiedDate}${sizeString}${itemDetailsString}${item.helpText ? `. ${item.helpText}` : ''}`
+        }
     })
-
-    return choice || false
+    return selectedOption
 }
 
 async function getDirDetails (dir) {
-    const userDir = path.resolve(dir)
-    const flowFiles = await getFlowFiles(userDir)
-    if (flowFiles.length > 0) {
-        const result = {
-            valid: true,
+    try {
+        const userDir = path.resolve(dir)
+        const flowFiles = await getFlowFiles(userDir)
+        if (flowFiles.length > 0) {
+            const result = {
+                valid: true,
+                userDir,
+                flowFiles,
+                packageFile: path.join(userDir, 'package.json')
+            }
+            return result
+        }
+        return {
+            valid: false,
             userDir,
-            flowFiles,
+            flowFiles: [],
             packageFile: path.join(userDir, 'package.json')
         }
-        return result
-    }
-    return {
-        valid: false,
-        userDir,
-        flowFiles: [],
-        packageFile: path.join(userDir, 'package.json')
+    } catch (_error) {
+        // If we cannot read the directory, return invalid
+        return {
+            valid: false,
+            userDir: dir,
+            flowFiles: [],
+            packageFile: null
+        }
     }
 }
 
@@ -174,7 +184,7 @@ async function getFlowFiles (userDir) {
         const skipFile = !!skipFiles.find(skipFile => new RegExp(skipFile).test(file))
         if (file.endsWith('.json') && !skipFile) {
             // check if the file is a Node-RED flows file or a Node-RED credentials file
-            const flowsFileDetails = await getFlowsFileDetails(userDir, file)
+            const flowsFileDetails = getFlowsFileDetails(userDir, file)
             if (flowsFileDetails?.isFlowsFile) {
                 jsonFiles.push(flowsFileDetails)
             }
@@ -183,7 +193,7 @@ async function getFlowFiles (userDir) {
     return jsonFiles
 }
 
-async function getFlowsFileDetails (dir, file) {
+function getFlowsFileDetails (dir, file) {
     const filePath = path.join(dir, file)
     const userDir = path.dirname(filePath)
     const result = {
@@ -195,7 +205,7 @@ async function getFlowsFileDetails (dir, file) {
         description: 'Not a valid Node-RED flows file'
     }
     try {
-        const fileData = await fsPromises.readFile(filePath, 'utf8')
+        const fileData = fs.readFileSync(filePath, 'utf8')
         const flows = JSON.parse(fileData)
         if (Array.isArray(flows)) {
             const duckTypeTest = flows.every(node => typeof node.id === 'string' && typeof node.type === 'string' && node.id.length > 0 && node.type.length > 0)
@@ -203,8 +213,10 @@ async function getFlowsFileDetails (dir, file) {
                 return result
             }
             result.isFlowsFile = true
-            result.description = `Press <enter> to import '${file}'`
             result.flows = flows
+            result.tabCount = flows.filter(flow => flow.type === 'tab').length
+            result.subflowCount = flows.filter(flow => flow.type === 'subflow').length
+            result.nodeCount = flows.filter(flow => flow.type !== 'global').length - result.tabCount - result.subflowCount
             const credFile = filePath.replace(/\.json$/, '_cred.json')
             if (existsSync(credFile)) {
                 result.credsFile = credFile
@@ -218,18 +230,17 @@ async function getFlowsFileDetails (dir, file) {
 }
 
 async function flowImport (suggestedDirs) {
-    const __askImportDirectory = module.exports.askImportDirectory // use the module definition so that mock tests can override it
-    const __askSelectFlowsFile = module.exports.askSelectFlowsFile
-    const importDetails = await __askImportDirectory(suggestedDirs)
+    const __askImport = module.exports.askImport // use the module definition so that mock tests can override it
+    const importDetails = await __askImport(suggestedDirs)
     if (importDetails === CHOICES.SKIP || importDetails.skip || !importDetails?.valid) {
         return null
     }
-    const selectedFlows = await __askSelectFlowsFile(importDetails.flowFiles)
+    const selectedFlows = getFlowsFileDetails(importDetails.dir, importDetails.name)
     if (selectedFlows) {
-        const userDir = path.dirname(selectedFlows.flowsFile)
+        const userDir = selectedFlows.userDir
         selectedFlows.credentials = {} // default to empty credentials
         selectedFlows.credentialSecret = null // default to null
-        selectedFlows.packageFile = path.join(userDir, 'package.json')
+        selectedFlows.packageFile = importDetails.packageFile
         if (selectedFlows.credsFile && existsSync(selectedFlows.credsFile)) {
             print(`Importing credentials '${selectedFlows.credsFile}'...`)
             selectedFlows.credentials = await fsPromises.readFile(selectedFlows.credsFile, 'utf8')
@@ -274,8 +285,7 @@ async function flowImport (suggestedDirs) {
 }
 
 module.exports = {
-    askImportDirectory,
-    askSelectFlowsFile,
+    askImport,
     getDirDetails,
     getFlowFiles,
     getFlowsFileDetails,


### PR DESCRIPTION
closes #415

## Description

* Adds component **fileBrowser**
* Scan additional common locations as potential node-red flows locations and offer as early choices during the import
* Updates dependencies for new functionality and latest chalk

![Code_3Amv1cDzzC](https://github.com/user-attachments/assets/bfc82b9b-506d-43d8-a2f9-aced505d3a4d)

TODO: Fix Tests


## Related Issue(s)

#415 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

