### PR TITLE
ci: Fix installer version set during a release build

### DIFF
--- a/.github/workflows/installer-release.yaml
+++ b/.github/workflows/installer-release.yaml
@@ -123,7 +123,7 @@ jobs:
         mkdir -p artifacts
         
         # Build with version from semantic-release
-        go build -ldflags "-X main.version=${VERSION:-${{ github.sha }}} -s -w" -o artifacts/${{ matrix.output }} main.go
+        go build -ldflags "-X main.instVersion=${VERSION:-${{ github.sha }}} -s -w" -o artifacts/${{ matrix.output }} main.go
         
         # Verify the binary was created
         if [ ! -f "artifacts/${{ matrix.output }}" ]; then


### PR DESCRIPTION
## Description

This pull request fixes the Device Agent Installer version set in the build step of the release pipeline.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

