### PR TITLE
ci: Rename `macos` to `darwin` in the DAI binary naming scheme

### DIFF
--- a/.github/workflows/installer-release.yaml
+++ b/.github/workflows/installer-release.yaml
@@ -80,10 +80,10 @@ jobs:
             output: flowfuse-device-installer-windows-amd64.exe
           - goos: darwin
             goarch: amd64
-            output: flowfuse-device-installer-macos-amd64
+            output: flowfuse-device-installer-darwin-amd64
           - goos: darwin
             goarch: arm64
-            output: flowfuse-device-installer-macos-arm64
+            output: flowfuse-device-installer-darwin-arm64
 
     steps:
     - name: Checkout
@@ -183,8 +183,8 @@ jobs:
           "flowfuse-device-installer-linux-arm64"
           "flowfuse-device-installer-linux-arm"
           "flowfuse-device-installer-windows-amd64.exe"
-          "flowfuse-device-installer-macos-amd64"
-          "flowfuse-device-installer-macos-arm64"
+          "flowfuse-device-installer-darwin-amd64"
+          "flowfuse-device-installer-darwin-arm64"
         )
         
         missing_files=()

--- a/installer/go/.releaserc.js
+++ b/installer/go/.releaserc.js
@@ -54,10 +54,10 @@ module.exports = {
           path: 'release-artifacts/flowfuse-device-installer-windows-amd64.exe'
         },
         {
-          path: 'release-artifacts/flowfuse-device-installer-macos-amd64'
+          path: 'release-artifacts/flowfuse-device-installer-darwin-amd64'
         },
         {
-          path: 'release-artifacts/flowfuse-device-installer-macos-arm64'
+          path: 'release-artifacts/flowfuse-device-installer-darwin-arm64'
         }
       ]
     }]


### PR DESCRIPTION
## Description

This pull request updates DAI release workflow and `semantic-release` action configuration to name macOS related binary as `darwin` instead of `macos` (allign with industry naming standard).

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

