### PR TITLE
fix(installer): link to installer's docs in installation summary

### DIFF
--- a/installer/go/cmd/install.go
+++ b/installer/go/cmd/install.go
@@ -115,7 +115,7 @@ func Install(nodeVersion, agentVersion, installerDir, url, otc string, update bo
 	logger.Info("The service is now running and will start automatically on system boot.")
 	logger.Info("You can now return to the FlowFuse platform and start creating Node-RED flows on your device")
 	logger.Info("For information on how to manage the FlowFuse Device Agent,")
-	logger.Info("  please refer to the documentation at https://github.com/FlowFuse/device-agent/installer/go/README.md")
+	logger.Info("  please refer to the documentation at https://github.com/FlowFuse/device-agent/blob/main/installer/go/README.md")
 
 	logger.LogFunctionExit("Install", "success", nil)
 	return nil


### PR DESCRIPTION
## Description

This pull request fixes link to the Device Agent Installer readme file presented on the installation summary.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

