### PR TITLE
Set the release in DAI `get` shell scripts to `1.1.0`

### DIFF
--- a/installer/get.ps1
+++ b/installer/get.ps1
@@ -9,7 +9,7 @@ $InstallDir = (Get-Location).Path
 # GitHub repository information
 $REPO_OWNER = "FlowFuse"
 $REPO_NAME = "device-agent"
-$RELEASE = "1.0.1"
+$RELEASE = "1.1.0"
 $RELEASE_TAG = "installer-v$RELEASE"
 $BINARY_PREFIX = "flowfuse-device-installer"
 

--- a/installer/get.sh
+++ b/installer/get.sh
@@ -9,7 +9,7 @@ set -e
 # GitHub repository information
 REPO_OWNER="FlowFuse"
 REPO_NAME="device-agent"
-RELEASE="1.0.1"
+RELEASE="1.1.0"
 RELEASE_TAG="installer-v$RELEASE"
 BINARY_PREFIX="flowfuse-device-installer"
 


### PR DESCRIPTION
## Description

This pull request updates the release number in DAI's "get" script to `1.1.0`. 

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

