### PR TITLE
Enable telemetry by default

### DIFF
--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -169,6 +169,9 @@ const runtimeSettings = {
             }
         }
     },
+    telemetry: {
+        enabled: true
+    },
     nodesDir: settings.nodesDir || null,
     [themeName]: { ...themeSettings },
     editorTheme: { ...editorTheme }


### PR DESCRIPTION
Enables update notifications for Node-RED 4.1 by default. User can still opt out via user settings within the editor.