### PR TITLE
fix(installer): Silent misleading device agent output

### DIFF
--- a/installer/go/pkg/nodejs/deviceagent.go
+++ b/installer/go/pkg/nodejs/deviceagent.go
@@ -308,11 +308,11 @@ func ConfigureDeviceAgent(url string, token string, baseDir string) error {
 	var configureCmd *exec.Cmd
 	switch runtime.GOOS {
 	case "linux", "darwin":
-		configureCmd = exec.Command("sudo", "--preserve-env=PATH", deviceAgentPath, "-o", token, "-u", url, "--otc-no-start")
+		configureCmd = exec.Command("sudo", "--preserve-env=PATH", deviceAgentPath, "-o", token, "-u", url, "--otc-no-start", "--installer-mode")
 		env := os.Environ()
 		configureCmd.Env = append(env, newPath)
 	case "windows":
-		configureCmd = exec.Command("cmd", "/C", deviceAgentPath, "-o", token, "-u", url, "--otc-no-start")
+		configureCmd = exec.Command("cmd", "/C", deviceAgentPath, "-o", token, "-u", url, "--otc-no-start", "--installer-mode")
 		env := os.Environ()
 		configureCmd.Env = append(env, newPath)
 	default:


### PR DESCRIPTION
## Description

This pull request adds `--installer-mode` flag to the device agent configuration command to remove unneeded output.

## Related Issue(s)

Closes https://github.com/FlowFuse/device-agent/issues/450

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

