### PR TITLE
ci: Update installer's "get" scripts on a release

### DIFF
--- a/.github/workflows/installer-release.yaml
+++ b/.github/workflows/installer-release.yaml
@@ -221,16 +221,23 @@ jobs:
     if: needs.calculate-version.outputs.new-release-published == 'true' && github.event.inputs.dry_run != 'true'
     
     steps:
+    - name: Generate a token
+      id: generate_token
+      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      with:
+        app_id: ${{ secrets.GH_BOT_APP_ID }}
+        private_key: ${{ secrets.GH_BOT_APP_KEY }}
+      
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ steps.generate_token.outputs.token }}
         
     - name: Configure Git
       run: |
-        git config user.name "${{ github.actor }}"
-        git config user.email "${{ github.actor }}@users.noreply.github.com"
+        git config user.name "$GitHub Actions Bot"
+        git config user.email "github.actions@users.noreply.github.com"
         
     - name: Update scripts
       run: |
@@ -249,7 +256,7 @@ jobs:
         
     - name: Commit and push changes
       env: 
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
       run: |
         VERSION="${{ needs.calculate-version.outputs.version }}"
         
@@ -259,11 +266,7 @@ jobs:
           exit 0
         fi
         
-        # Stage changes
+        # Stage, commit, and push changes
         git add ./installer/get.sh ./installer/get.ps1
-        
-        # Commit with skip ci to prevent triggering workflows
         git commit -m "chore: update installer scripts to version $VERSION [skip ci]"
-        
-        # Push changes
         git push origin main

--- a/.github/workflows/installer-release.yaml
+++ b/.github/workflows/installer-release.yaml
@@ -213,3 +213,57 @@ jobs:
         dry_run: false
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  update-installer-scripts:
+    name: Update Download Scripts
+    runs-on: ubuntu-latest
+    needs: [calculate-version, release]
+    if: needs.calculate-version.outputs.new-release-published == 'true' && github.event.inputs.dry_run != 'true'
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: Configure Git
+      run: |
+        git config user.name "${{ github.actor }}"
+        git config user.email "${{ github.actor }}@users.noreply.github.com"
+        
+    - name: Update scripts
+      run: |
+        VERSION="${{ needs.calculate-version.outputs.version }}"
+        echo "Updating installer scripts to version: $VERSION"
+        
+        # Update scripts
+        sed -i "s/^RELEASE=.*/RELEASE=\"$VERSION\"/" ./installer/get.sh
+        sed -i "s/^\$RELEASE = .*/\$RELEASE = \"$VERSION\"/" ./installer/get.ps1
+        
+        # Verify changes
+        echo "Updated get.sh:"
+        grep "^RELEASE=" ./installer/get.sh
+        echo "Updated get.ps1:"
+        grep "^\$RELEASE = " ./installer/get.ps1
+        
+    - name: Commit and push changes
+      env: 
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        VERSION="${{ needs.calculate-version.outputs.version }}"
+        
+        # Ensure there are changes to commit
+        if git diff --quiet; then
+          echo "No changes to commit"
+          exit 0
+        fi
+        
+        # Stage changes
+        git add ./installer/get.sh ./installer/get.ps1
+        
+        # Commit with skip ci to prevent triggering workflows
+        git commit -m "chore: update installer scripts to version $VERSION [skip ci]"
+        
+        # Push changes
+        git push origin main


### PR DESCRIPTION
## Description

This pull request extends existing `Installer Release` workflow by adding a job responsible for updating the `RELEASE` variable in  "get" scripts (`./installer/get.sh` and `./installer/get.ps1`) - scripts used suring seamless Device Agent onboarding. 

## Related Issue(s)

Closes https://github.com/FlowFuse/device-agent/issues/433

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

