### PR TITLE
Clear blueprint cache before repopulating

### DIFF
--- a/lib/plugins/node_modules/@flowfuse/flowfuse-blueprint-plugin/blueprintPlugin.js
+++ b/lib/plugins/node_modules/@flowfuse/flowfuse-blueprint-plugin/blueprintPlugin.js
@@ -28,7 +28,7 @@ module.exports = function (RED) {
     // We do not retrieve the blueprint list on every request; we get it once and cache the result.
     // The cache is expired after 2 minutes. Most interactions with the library will be short-lived
     // and within this interval - so this is the right balance between performance and freshness.
-    const blueprintCache = {}
+    let blueprintCache = {}
     let cacheLastRefreshedAt = 0
     const CACHE_EXPIRY_PERIOD = 2 * 60 * 1000 // 2 minutes in milliseconds
 
@@ -153,6 +153,7 @@ module.exports = function (RED) {
                         team: this.teamID
                     }
                 })
+                blueprintCache = {}
                 const blueprints = JSON.parse(result.body)
                 for (const blueprint of blueprints.blueprints) {
                     blueprintCache[blueprint.category || 'blueprints'] = blueprintCache[blueprint.category || 'blueprints'] || []


### PR DESCRIPTION
Fixes https://github.com/FlowFuse/nr-launcher/issues/353 in the Device Agent

Clear the bp cache before repopulating to avoid duplicates.