### PR TITLE
Disable npm audit when installing modules

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -128,7 +128,7 @@ class Launcher {
             return fs.symlink(sourceDir, targetDir, 'dir')
         } else {
             this.installProcess = new Promise((resolve, reject) => {
-                childProcess.exec('npm install --production', {
+                childProcess.exec('npm install --no-fund --no-audit', {
                     cwd: this.projectDir
                 }, (error, stdout, stderr) => {
                     if (!error) {


### PR DESCRIPTION
Part of #455 

## Description

Removes the audit and funding checks in the `npm install` command.

 - The user doesn't see the output, so it adds no value.
 - Removes an http request to the registry as part of the audit step