### PR TITLE
Change default checkin interval to 60 seconds

### DIFF
--- a/lib/cli/args.js
+++ b/lib/cli/args.js
@@ -24,7 +24,7 @@ module.exports = [
         name: 'interval',
         alias: 'i',
         type: Number,
-        defaultValue: 30,
+        defaultValue: 60,
         typeLabel: '{underline secs}',
         group: 'main'
     },


### PR DESCRIPTION
fixes #465

## Description

<!-- Describe your changes in detail -->
changes default check in time to 60 seconds to halve load on db

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#465 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

