### PR TITLE
Use nr-table-nodes local src if in development mode

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -79,7 +79,7 @@ class Launcher {
             }
         }
         // if we are working in a development env and the nr-table-nodes src is available in the right place,
-        // then use the development version of the nr-mqtt-nodes
+        // then use the development version of the nr-table-nodes
         if (packageData.dependencies?.['@flowfuse/nr-table-nodes'] && process.env.NODE_ENV === 'development') {
             const devPath = path.join(__dirname, '..', '..', 'nr-table-nodes')
             if (existsSync(devPath)) {


### PR DESCRIPTION
Opportunistic PR - spotted the DX for nr-table-nodes was missing while developing nr-mqtt-nodes

