### PR TITLE
refactor(installer): Adjust config selection prompt when OTC not provided

### DIFF
--- a/installer/go/pkg/nodejs/deviceagent.go
+++ b/installer/go/pkg/nodejs/deviceagent.go
@@ -359,11 +359,16 @@ func ConfigureDeviceAgent(url, token, baseDir string, port int) (string, bool, e
 	} else {
 
 		logger.Info("No OTC (One-Time Code) provided. Automatic configuration is not possible.")
-		logger.Info("You can either:")
-		logger.Info("  1. Install the device agent only (you'll need to configure it manually later)")
-		logger.Info("  2. Provide a device configuration file now")
-
-		configProvided := utils.PromptYesNo("Do you want to provide a device agent configuration now?", true)
+		options := []string{
+			"Provide a device configuration file now",
+			"Install the device agent only (you'll need to configure it manually later)",
+		}
+		choice, err := utils.PromptOption("You can either:", options, 0)
+		if err != nil {
+			logger.Error("Failed to get user selection: %v", err)
+			return "", false, fmt.Errorf("failed to get user selection: %w", err)
+		}
+		configProvided := choice == 0
 
 		if configProvided {
 			// Manual configuration mode


### PR DESCRIPTION
## Description

This pull request adjusts the user selection prompt if OTC is not provided. It replaces unclear "yes/no" prompt with options selector.

## Related Issue(s)

Closes https://github.com/FlowFuse/device-agent/issues/481

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

