### PR TITLE
ci: Remove `skip ci` tag from installer scripts commit message

### DIFF
--- a/.github/workflows/installer-release.yaml
+++ b/.github/workflows/installer-release.yaml
@@ -268,5 +268,5 @@ jobs:
         
         # Stage, commit, and push changes
         git add ./installer/get.sh ./installer/get.ps1
-        git commit -m "chore: update installer scripts to version $VERSION [skip ci]"
+        git commit -m "chore: update installer scripts to version $VERSION"
         git push origin main


### PR DESCRIPTION
## Description

This pull request removes the `skip ci` tag from the commit message responsible for the automatic update of the Device Agent Installer download scripts.  
The reason for this change is to fully automate the release of the download scripts. Once the tag is removed, the `Publish Installer Scripts to GitHub Pages` workflow will be triggered automatically.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

