### PR TITLE
fix(installer): fix linux/unix binary lookup 

### DIFF
--- a/installer/go/pkg/utils/utils.go
+++ b/installer/go/pkg/utils/utils.go
@@ -199,20 +199,20 @@ func CheckPermissions() error {
 }
 
 // checkUnixPermissions validates that sudo can be used by the current user and, if necessary,
-// interactively prompts once to cache credentials.
+// interactively prompts for password to cache credentials for further installer execution.
 //
 // Behavior:
 //  1. Inform the user about upcoming sudo usage and potential prompts.
 //  2. Ensure sudo is installed; return error if missing.
 //  3. Try non-interactive sudo timestamp validation: `sudo -n -v`.
 //     - If it succeeds, return.
-//  4. Detect passwordless sudo by attempting a non-interactive no-op (`sudo -n /bin/true` or `sudo -n true`).
+//  4. Detect passwordless sudo by attempting a non-interactive command (`sudo -n /bin/true` or `sudo -n true`).
 //     - If it succeeds, return without prompting.
-//  5. Fall back to interactive `sudo -v` to cache credentials now.
+//  5. Fallback to interactive `sudo -v` to cache credentials now.
 //     - If this fails (user cancels or denied), return an error because sudo is required.
 //
 // Returns:
-//   - nil when sudo is usable now (passwordless or credentials cached)
+//   - nil when sudo is usable (passwordless or credentials cached)
 //   - error if sudo is missing or interactive authentication fails
 func checkUnixPermissions() error {
 	logger.Info("This installer will perform operations that require sudo.")


### PR DESCRIPTION
## Description

This pull request fixes how existance of validation of binaries is performed on a linux/unix systems.
Introduced changes ensures, that proper shell account is used while validating path to selected binary.
Additionally, this pull request 
* refactors the way how `sudo` access is validated
* increase debug messages in the `CreateServiceUser` function

How to test:
1. Use `which` command to detect where `useradd` and `adduser` binaries are stored
```
which useradd
/usr/sbin/useradd
which adduser
/usr/sbin/adduser
```
2. Exclude `/usr/sbin` from the PATH
```
PATH=$(printf "%s" "$PATH" | tr ':' '\n' | grep -v '^/usr/sbin$' | paste -sd:)
```
3. Ensure `useradd` and `adduser` are not available anymore using commands from step 1. If they are, due to some directories symlinks, adjust command from step 2 to exclude another directories from PATH environmental variable
4. Once `useradd` and `adduser` are not available for current user, use the Device Agent Installer to onboard Device Agent. Installation should complete with successs - `flowfuse` shell account should exists with `/home/flowfuse` homedir

Cleanup: uninstall the Device Agent using `--uninstall` flag for the Device Agent Installer.

## Related Issue(s)

Fixes https://github.com/FlowFuse/device-agent/issues/500 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

