### PR TITLE
ci: Bump go version in `Installer Release` workflow

### DIFF
--- a/.github/workflows/installer-release.yaml
+++ b/.github/workflows/installer-release.yaml
@@ -10,7 +10,7 @@ on:
         required: false
 
 env:
-  GO_VERSION: '1.21'
+  GO_VERSION: '1.24.2'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Description

This pull request bumps the GO version to `1.24.2` in the `Installer Release` workflow.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

