### PR TITLE
fix(installer): build statically linked binary

### DIFF
--- a/.github/workflows/installer-build.yaml
+++ b/.github/workflows/installer-build.yaml
@@ -131,6 +131,7 @@ jobs:
         GOOS: ${{ matrix.goos }}
         GOARCH: ${{ matrix.goarch }}
         VERSION: 'ci-${{ github.run_id }}'
+        CGO_ENABLED: 0
       run: |
         echo "Building for $GOOS/$GOARCH..."
         BINARY_NAME="flowfuse-device-installer-${{ matrix.goos }}-${{ matrix.goarch }}"

--- a/.github/workflows/installer-release.yaml
+++ b/.github/workflows/installer-release.yaml
@@ -106,6 +106,7 @@ jobs:
         GOOS: ${{ matrix.goos }}
         GOARCH: ${{ matrix.goarch }}
         VERSION: ${{ needs.calculate-version.outputs.version }}
+        CGO_ENABLED: 0
       run: |
         echo "Building ${{ matrix.output }} for ${{ matrix.goos }}/${{ matrix.goarch }}..."
         echo "Using version: ${VERSION:-${{ github.sha }}}"

--- a/installer/go/makefile
+++ b/installer/go/makefile
@@ -14,12 +14,12 @@ default: help
 build: ## builds the application for all platforms
 	mkdir -p out/{linux,macos,windows}
 	@echo "Building ${APP_NAME} version ${VERSION}..."
-	GOARCH=amd64 GOOS=linux go build -ldflags "-X main.instVersion=${VERSION}" -o ./out/linux/${APP_NAME}-linux-amd64 main.go
-	GOARCH=arm64 GOOS=linux go build -ldflags "-X main.instVersion=${VERSION}" -o ./out/linux/${APP_NAME}-linux-arm64 main.go
-	GOARCH=arm GOOS=linux go build -ldflags "-X main.instVersion=${VERSION}" -o ./out/linux/${APP_NAME}-linux-arm main.go
-	GOARCH=amd64 GOOS=windows go build -ldflags "-X main.instVersion=${VERSION}" -o ./out/windows/${APP_NAME}-windows-amd64.exe main.go
-	GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.instVersion=${VERSION}" -o ./out/macos/${APP_NAME}-macos-amd64 main.go
-	GOOS=darwin GOARCH=arm64 go build -ldflags "-X main.instVersion=${VERSION}" -o ./out/macos/${APP_NAME}-macos-arm64 main.go
+	GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags "-X main.instVersion=${VERSION}" -o ./out/linux/${APP_NAME}-linux-amd64 main.go
+	GOARCH=arm64 GOOS=linux CGO_ENABLED=0 go build -ldflags "-X main.instVersion=${VERSION}" -o ./out/linux/${APP_NAME}-linux-arm64 main.go
+	GOARCH=arm GOOS=linux CGO_ENABLED=0 go build -ldflags "-X main.instVersion=${VERSION}" -o ./out/linux/${APP_NAME}-linux-arm main.go
+	GOARCH=amd64 GOOS=windows CGO_ENABLED=0 go build -ldflags "-X main.instVersion=${VERSION}" -o ./out/windows/${APP_NAME}-windows-amd64.exe main.go
+	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-X main.instVersion=${VERSION}" -o ./out/macos/${APP_NAME}-macos-amd64 main.go
+	GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -ldflags "-X main.instVersion=${VERSION}" -o ./out/macos/${APP_NAME}-macos-arm64 main.go
 
 clean: ## cleans the build artifacts
 	go clean


### PR DESCRIPTION
## Description

This pull request disables dependency to C libraries by setting the `CGO_ENABLED` environmental variable to `0`.
In result, binaries will run on target systems without requiring specific libc versions (statically linked).

## Related Issue(s)

fixes: https://github.com/FlowFuse/device-agent/issues/417

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

