### PR TITLE
fix(installer): fix OpenRC service template to properly handle command arguments

### DIFF
--- a/installer/go/pkg/service/templates.go
+++ b/installer/go/pkg/service/templates.go
@@ -149,7 +149,8 @@ const OpenRCServiceTemplate = `#!/sbin/openrc-run
 name="FlowFuse Device Agent"
 description="FlowFuse Device Agent"
 supervisor="supervise-daemon"
-command="{{.NodeBinDir}}/flowfuse-device-agent --dir {{.WorkDir}} --port {{.Port}}"
+command="{{.NodeBinDir}}/flowfuse-device-agent"
+command_args="--dir {{.WorkDir}} --port {{.Port}}"
 supervise_daemon_args=" -d {{.WorkDir}} --stdout {{.LogFile}} --stderr {{.ErrorLogFile}} -e "PATH=\"{{.NodeBinDir}}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"\""
 command_user="{{.User}}"
 


### PR DESCRIPTION
## Description

This pull request adjusts the OpenRS service template to properly handle additional`flowfuse-device-agent` command arguments.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

