### PR TITLE
Clarify version output by prefixing with FlowFuse Device Agent

### DIFF
--- a/lib/AgentManager.js
+++ b/lib/AgentManager.js
@@ -79,7 +79,7 @@ class AgentManager {
         info('Agent starting...')
         try {
             await this.reloadConfig()
-            info(`Version: ${this.configuration.version}`)
+            info(`FlowFuse Device Agent Version: ${this.configuration.version}`)
             if (this.configuration.provisioningMode) {
                 info('Mode: Provisioning Mode')
             } else {


### PR DESCRIPTION
The version output on startup was showing just "Version: X.X.X" which could be confusing as it might be mistaken for the Node-RED version. Now it clearly shows "FlowFuse Device Agent Version: X.X.X" to avoid any confusion about what component's version is being displayed.

Fixes https://github.com/FlowFuse/device-agent/issues/509

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 