### PR TITLE
fix(installer): Link to the docs on disk error message

### DIFF
--- a/installer/go/pkg/validate/validate.go
+++ b/installer/go/pkg/validate/validate.go
@@ -291,7 +291,10 @@ func checkFreeDiskSpace(customWorkDir string, requiredBytes uint64) error {
 		if !ok {
 			requiredMB := float64(requiredBytes) / (1024 * 1024)
 			freeMB := float64(free) / (1024 * 1024)
-			err := fmt.Errorf("insufficient disk space in %s (%s): need at least %.1f MB, available %.1f MB", t.label, t.path, requiredMB, freeMB)
+			// err := fmt.Errorf("insufficient disk space in %s (%s): need at least %.1f MB, available %.1f MB", t.label, t.path, requiredMB, freeMB)
+			err := fmt.Errorf("insufficient disk space in %s (%s): need at least %.1f MB, available %.1f MB\n" +
+				"For information on how to handle this error, visit: http://flowfuse.com/docs/device-agent/install/device-agent-installer/#disk-space-check-failed-error",
+    		t.label, t.path, requiredMB, freeMB)
 			logger.LogFunctionExit("checkFreeDiskSpace", nil, err)
 			return err
 		}

--- a/installer/go/pkg/validate/validate.go
+++ b/installer/go/pkg/validate/validate.go
@@ -293,8 +293,8 @@ func checkFreeDiskSpace(customWorkDir string, requiredBytes uint64) error {
 			freeMB := float64(free) / (1024 * 1024)
 			// err := fmt.Errorf("insufficient disk space in %s (%s): need at least %.1f MB, available %.1f MB", t.label, t.path, requiredMB, freeMB)
 			err := fmt.Errorf("insufficient disk space in %s (%s): need at least %.1f MB, available %.1f MB\n" +
-				"For information on how to handle this error, visit: http://flowfuse.com/docs/device-agent/install/device-agent-installer/#error%3A-disk-space-check-failed",
-    		t.label, t.path, requiredMB, freeMB)
+				"For information on how to handle this error, visit: http://flowfuse.com/docs/device-agent/install/device-agent-installer/#error%%3A-disk-space-check-failed",
+				t.label, t.path, requiredMB, freeMB)
 			logger.LogFunctionExit("checkFreeDiskSpace", nil, err)
 			return err
 		}

--- a/installer/go/pkg/validate/validate.go
+++ b/installer/go/pkg/validate/validate.go
@@ -293,7 +293,7 @@ func checkFreeDiskSpace(customWorkDir string, requiredBytes uint64) error {
 			freeMB := float64(free) / (1024 * 1024)
 			// err := fmt.Errorf("insufficient disk space in %s (%s): need at least %.1f MB, available %.1f MB", t.label, t.path, requiredMB, freeMB)
 			err := fmt.Errorf("insufficient disk space in %s (%s): need at least %.1f MB, available %.1f MB\n" +
-				"For information on how to handle this error, visit: http://flowfuse.com/docs/device-agent/install/device-agent-installer/#disk-space-check-failed-error",
+				"For information on how to handle this error, visit: http://flowfuse.com/docs/device-agent/install/device-agent-installer/#error%3A-disk-space-check-failed",
     		t.label, t.path, requiredMB, freeMB)
 			logger.LogFunctionExit("checkFreeDiskSpace", nil, err)
 			return err


### PR DESCRIPTION
## Description

WARNING: this PR should be merged once https://github.com/FlowFuse/flowfuse/pull/6073 is published.
This pull request extends the error message shown to the user when lack of available disk space validation fails.

## Related Issue(s)

https://github.com/FlowFuse/device-agent/issues/511

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

