### PR TITLE
fix(installer): Add documentation links in the installation summary

### DIFF
--- a/installer/go/pkg/utils/utils.go
+++ b/installer/go/pkg/utils/utils.go
@@ -1141,6 +1141,9 @@ func ShowInstallSummary(installMode, url, workDir string) {
 	}
 
 	logger.Info("")
-	logger.Info("For more details on managing the FlowFuse Device Agent, including commands for starting, stopping, and updating the service, visit:")
-	logger.Info("https://flowfuse.com/docs/device-agent/install/overview")
+	logger.Info("Further reading:")
+	logger.Info("  - To learn how to check the service status, visit https://flowfuse.com/docs/device-agent/install/device-agent-installer/#check-the-device-agent-service-status")
+	logger.Info("  - To learn how to manage the service (start, stop, restart), visit https://flowfuse.com/docs/device-agent/install/device-agent-installer/#managing-the-device-agent-service")
+	logger.Info("  - To learn how to view logs, visit https://flowfuse.com/docs/device-agent/install/device-agent-installer/#viewing-device-agent-log-files")
+	logger.Info("")
 }


### PR DESCRIPTION
## Description

This pull request improves the Device Agent Installer installation summary by adding links to the documentation that provides to a user useful knoledge about managing the Device Agent after installation.

## Related Issue(s)

https://github.com/FlowFuse/device-agent/issues/512

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

