### PR TITLE
Ensure correct NR version reported with module_cache

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -279,9 +279,20 @@ class Agent {
             licensed: this.config.licensed
         }
         if (this.launcher?.readPackage) {
-            const { modules } = this.launcher.readPackage()
-            if (semver.valid(modules['node-red']) !== null) {
-                state.nodeRedVersion = modules['node-red']
+            if (!this.config.moduleCache) {
+                const { modules } = this.launcher.readPackage()
+                if (semver.valid(modules['node-red']) !== null) {
+                    state.nodeRedVersion = modules['node-red']
+                } else {
+                    try {
+                        const nrPackPath = path.join(this.launcher.projectDir, 'node_modules/node-red/package.json')
+                        const content = readFileSync(nrPackPath)
+                        const packJSON = JSON.parse(content)
+                        state.nodeRedVersion = packJSON.version
+                    } catch (err) {
+                        // Bad node-red install
+                    }
+                }
             } else {
                 try {
                     const nrPackPath = path.join(this.launcher.projectDir, 'node_modules/node-red/package.json')


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
When using moduleCache the Node-RED version in the cache overrides the version in the snapshot, but the agent still reports the snapshot version.

This fix sends the correct version and ensures the correct editor libraries are proxied.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

