### PR TITLE
ci: Run tests against Node `22` and `24`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,8 @@ jobs:
       matrix:
         node-version: [14, 16, 18, 20, 22, 24]
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - name: Checkout
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
       with:
@@ -27,7 +28,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
     - name: Run linting checks
-      # if: ${{ matrix.node-version == 18 }}
+      if: ${{ matrix.node-version == 20 }}
       run: npm run lint
     - name: Run tests
       run: npm run test


### PR DESCRIPTION
## Description

This pull request extends the list of Node.js versions against which tests are executed.
Additionally, it changes the Node.js version used for linting from `18` to `20`.

## Related Issue(s)

Closes https://github.com/FlowFuse/device-agent/issues/549

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

