### PR TITLE
Support for forceUpdate flag to allow snapshot deploy whilst in dev mode

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -517,7 +517,7 @@ class Agent {
 
             /** A flag to indicate execution should skip to the update step */
             const skipToUpdate = newState?.reloadSnapshot === true
-            
+
             /** A flag to indicate the update should be applied even if in developerMode */
             let forceUpdate = false
             if (newState?.forceUpdate) {

--- a/test/unit/lib/agent_spec.js
+++ b/test/unit/lib/agent_spec.js
@@ -1030,7 +1030,6 @@ describe('Agent', function () {
             agent.httpClient.getSettings.called.should.be.true('getSettings was not called when snapshot changed') // getSettings should be called because platform will have updated settings from the new snapshot (e.g. FF_SNAPSHOT_ID will be different)
         })
 
-
         it('Checks in when switching to developer mode (HTTP)', async function () {
             const agent = createHTTPAgent()
             agent.currentProject = 'projectId'


### PR DESCRIPTION
Closes #568 

Part of https://github.com/FlowFuse/flowfuse/issues/6496

This adds support for applying a new snapshot when in Developer mode.

This is only done if the status update received from the platform includes the new flag `forceUpdate`.