### PR TITLE
feat(AI): Conditionally load nr-assistant dependency based on feature flag

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -71,6 +71,10 @@ class Launcher {
         debug(`Updating package.json: ${this.files.packageJSON}`)
         const packageData = JSON.parse(JSON.stringify(packageJSONTemplate))
         packageData.dependencies = JSON.parse(JSON.stringify(this.snapshot.modules))
+        // if assistant is explicitly disabled, remove the assistant plugin from dependencies
+        if (this.settings?.assistant?.enabled === false) {
+            delete packageData.dependencies['@flowfuse/nr-assistant']
+        }
         // if we are working in a development env and the project nodes src is available in the right place,
         // then use the development version of the project nodes
         if (packageData.dependencies?.['@flowfuse/nr-project-nodes'] && process.env.NODE_ENV === 'development') {

--- a/test/unit/lib/launcher_spec.js
+++ b/test/unit/lib/launcher_spec.js
@@ -416,6 +416,35 @@ describe('Launcher', function () {
         pkg.name.should.eqls('TEST_PROJECT')
         pkg.version.should.eqls('0.0.0-aaaabbbbcccc')
     })
+    it('Removes nr-assistant from package.json when assistant is explicitly disabled', async function () {
+        const snapshot = JSON.parse(JSON.stringify(setup.snapshot))
+        snapshot.modules['@flowfuse/nr-assistant'] = '0.1.0'
+        const settings = { assistant: { enabled: false } }
+        const launcher = newLauncher({ config }, null, 'projectId', snapshot, settings)
+        await launcher.writePackage()
+        const pkgFile = await fs.readFile(path.join(config.dir, 'project', 'package.json'))
+        const pkg = JSON.parse(pkgFile)
+        pkg.dependencies.should.not.have.property('@flowfuse/nr-assistant')
+    })
+    it('Keeps nr-assistant in package.json when assistant is enabled', async function () {
+        const snapshot = JSON.parse(JSON.stringify(setup.snapshot))
+        snapshot.modules['@flowfuse/nr-assistant'] = '0.1.0'
+        const settings = { assistant: { enabled: true } }
+        const launcher = newLauncher({ config }, null, 'projectId', snapshot, settings)
+        await launcher.writePackage()
+        const pkgFile = await fs.readFile(path.join(config.dir, 'project', 'package.json'))
+        const pkg = JSON.parse(pkgFile)
+        pkg.dependencies.should.have.property('@flowfuse/nr-assistant', '0.1.0')
+    })
+    it('Keeps nr-assistant in package.json when assistant settings are not configured', async function () {
+        const snapshot = JSON.parse(JSON.stringify(setup.snapshot))
+        snapshot.modules['@flowfuse/nr-assistant'] = '0.1.0'
+        const launcher = newLauncher({ config }, null, 'projectId', snapshot)
+        await launcher.writePackage()
+        const pkgFile = await fs.readFile(path.join(config.dir, 'project', 'package.json'))
+        const pkg = JSON.parse(pkgFile)
+        pkg.dependencies.should.have.property('@flowfuse/nr-assistant', '0.1.0')
+    })
 
     it('Updates package.json with user defined Node-RED version', async function () {
         const newSettings = {


### PR DESCRIPTION
## Description

 - Removes nr-assistant from package.json when assistant is explicitly disabled: enabled: false strips the dependency                                                                                                                                                                                             
 - Keeps nr-assistant in package.json when assistant is enabled: enabled: true preserves it                                                                                                                                                                                                                       
 - Keeps nr-assistant in package.json when assistant settings are not configured: no settings passed, dependency stays   

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/7325

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

