### PR TITLE
fix: load FlowFuse editor behavior regardless of theme 

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -310,6 +310,22 @@ class Launcher {
             ]
         }
 
+        settings['flowfuse-common'] = {
+            launcherVersion: this.config.version,
+            projectURL: `${this.config.forgeURL}/device/${this.config.deviceId}/overview`
+        }
+        // Load editor behaviour via page.scripts so it runs regardless of theme.
+        const nrThemeDir = settings.nodesDir.find(dir => existsSync(path.join(dir, 'lib', 'theme', 'common', 'forge-platform.js')))
+        if (nrThemeDir) {
+            const commonDir = path.join(nrThemeDir, 'lib', 'theme', 'common')
+            const pageScripts = [path.join(commonDir, 'forge-platform.js')]
+            const brandedTheme = !this.config.theme || ['forge', 'forge-light', 'forge-dark'].includes(this.config.theme)
+            if (brandedTheme) {
+                pageScripts.push(path.join(commonDir, 'forge-branding.js'))
+            }
+            settings.editorTheme.page = { scripts: pageScripts }
+        }
+
         if (this.settings?.editor?.apiMaxLength) {
             settings.apiMaxLength = bytes(this.settings.editor.apiMaxLength)
         }

--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -175,6 +175,7 @@ const runtimeSettings = {
     },
     nodesDir: settings.nodesDir || null,
     [themeName]: { ...themeSettings },
+    'flowfuse-common': { ...(settings['flowfuse-common'] || {}) },
     editorTheme: { ...editorTheme }
 }
 

--- a/test/unit/lib/launcher_spec.js
+++ b/test/unit/lib/launcher_spec.js
@@ -125,6 +125,15 @@ describe('Launcher', function () {
         settings.flowforge.should.have.property('projectID', 'PROJECTID')
         settings.flowforge.should.not.have.property('projectLink')
     })
+    it('Write Settings - exposes flowfuse-common values for the editor scripts', async function () {
+        const launcher = newLauncher({ config: { ...configWithPlatformInfo, version: '9.9.9' } }, null, 'PROJECTID', setup.snapshot)
+        await launcher.writeSettings()
+        const setFile = await fs.readFile(path.join(config.dir, 'project', 'settings.json'))
+        const settings = JSON.parse(setFile)
+        settings.should.have.property('flowfuse-common')
+        settings['flowfuse-common'].should.have.property('launcherVersion', '9.9.9')
+        settings['flowfuse-common'].should.have.property('projectURL', 'https://test/device/deviceid/overview')
+    })
     it('Write Settings - without broker, application bound device', async function () {
         const launcher = newLauncher({ config }, 'APP-ID', null, setup.snapshot)
         await launcher.writeSettings()


### PR DESCRIPTION


## Description

- See details here: https://github.com/FlowFuse/flowfuse/issues/7554#issue-4686667624
- See test plan here: https://github.com/FlowFuse/flowfuse/issues/7549#issuecomment-4734724176

### ⚠️ This is part of a 3 part change that all should go in parallel. 

**Parent epic:**  First party theme event handlers not loaded when no FlowFuse theme is active
[ #7549](https://github.com/FlowFuse/flowfuse/issues/7549) 

**Subtasks:** 

1. Load FlowFuse editor behaviour regardless of theme (nr-launcher)
https://github.com/FlowFuse/flowfuse/issues/7553
2. Load FlowFuse editor behavior regardless of theme (device-agent)
https://github.com/FlowFuse/flowfuse/issues/7554
3. Device editor: redirect parent instead of iframe (flowfuse frontend)
https://github.com/FlowFuse/flowfuse/issues/7569

## Related Issue(s)

Resolves https://github.com/FlowFuse/flowfuse/issues/7554

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

