### PR TITLE
feat!: Build Node.Js 22 based container and set it as a default one

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -20,6 +20,8 @@ jobs:
             platforms: linux/amd64,linux/arm64,linux/arm/v7
           - node: 20
             platforms: linux/amd64,linux/arm64,linux/arm/v7
+          - node: 22
+            platforms: linux/amd64,linux/arm64,linux/arm/v7
           - node: 24
             platforms: linux/amd64,linux/arm64
     steps:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,65 @@
+name: Docker build
+
+on:
+  pull_request:
+    paths:
+      - 'docker/**'
+      - '.github/workflows/docker-build.yaml'
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      matrix:
+        include:
+          - node: 18
+            platforms: linux/amd64,linux/arm64,linux/arm/v7
+          - node: 20
+            platforms: linux/amd64,linux/arm64,linux/arm/v7
+          - node: 24
+            platforms: linux/amd64,linux/arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker
+        uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 #v4.7.0
+        with:
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
+      - name: Build Docker image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: ${{ matrix.platforms }}
+          tags: flowfuse-device-agent-pr:${{ matrix.node }}-scan
+          push: false
+          load: true
+          build-args: |
+            NODE_VERSION=${{ matrix.node }}
+
+      - name: Perform SAST scan
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+        with:
+          image-ref: flowfuse-device-agent-pr:${{ matrix.node }}-scan
+          trivy-config: .github/trivy.yaml
+          version: 'v0.69.2' # https://github.com/aquasecurity/trivy-action/issues/512
+          output: 'sast-results.sarif'
+
+      - name: Upload scan results
+        uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
+        with:
+          sarif_file: sast-results.sarif

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -24,10 +24,10 @@ jobs:
             platforms: linux/amd64,linux/arm64
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Docker
-        uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 #v4.7.0
+        uses: docker/setup-docker-action@0234bb73ccb40f0c430b795634f9247e2b5c2d23 #v5.2.0
         with:
           daemon-config: |
             {
@@ -37,10 +37,10 @@ jobs:
             }
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Build Docker image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: docker/Dockerfile
@@ -52,14 +52,13 @@ jobs:
             NODE_VERSION=${{ matrix.node }}
 
       - name: Perform SAST scan
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: flowfuse-device-agent-pr:${{ matrix.node }}-scan
           trivy-config: .github/trivy.yaml
-          version: 'v0.69.2' # https://github.com/aquasecurity/trivy-action/issues/512
           output: 'sast-results.sarif'
 
       - name: Upload scan results
-        uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: sast-results.sarif

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   docker-build:
+    name: 'Build docker image: Node ${{ matrix.node }}'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -28,6 +28,8 @@ jobs:
             platforms: linux/amd64, linux/arm64, linux/arm/v7
           - node: 20
             platforms: linux/amd64, linux/arm64, linux/arm/v7
+          - node: 22
+            platforms: linux/amd64,linux/arm64,linux/arm/v7
           - node: 24
             platforms: linux/amd64, linux/arm64
     steps:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -40,9 +40,9 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           tags: |
-            type=semver,event=tag,pattern=v{{version}},enable=${{ matrix.node == 18}}
+            type=semver,event=tag,pattern=v{{version}},enable=${{ matrix.node == 22}}
             type=semver,event=tag,pattern=v{{version}}-${{ matrix.node }}
-            type=raw,value=latest,enable=${{ matrix.node == 18}}
+            type=raw,value=latest,enable=${{ matrix.node == 22}}
             type=raw,value=latest-${{matrix.node}}
           flavor: |
             latest=false


### PR DESCRIPTION
## Description

This pull request introduces the following BREAKING CHANGES:
* extends the build pipeline to build containers using the Node22 base container
* set Node22-based container images as one for `latest` and `$version` docker tags

## Related Issue(s)

Closes https://github.com/FlowFuse/device-agent/issues/646

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

