### PR TITLE
feat: Add support for bearer tokens

### DIFF
--- a/lib/plugins/node_modules/@flowfuse/flowfuse-auth/httpAuthMiddleware.js
+++ b/lib/plugins/node_modules/@flowfuse/flowfuse-auth/httpAuthMiddleware.js
@@ -8,8 +8,8 @@ const { Strategy } = require('./strategy')
 let options
 let passport
 let httpNodeApp
-// let client
-// const httpTokenCache = {}
+let client
+const httpTokenCache = {}
 
 module.exports = {
     init (_options) {
@@ -19,38 +19,38 @@ module.exports = {
                 try {
                     if (req.session.ffSession) {
                         next()
-                    // Not support bearer token support for now
-                    // } else if (req.get('Authorization')?.startsWith('Bearer')) {
-                    //     // We should include the Project ID and the path along with the token
-                    //     // to be checked to allow scoping tokens
-                    //     const token = req.get('Authorization').split(' ')[1]
-                    //     const cacheHit = httpTokenCache[token]
-                    //     if (cacheHit) {
-                    //         const age = (Date.now() - cacheHit.age) / 1000
-                    //         if (age < 300) {
-                    //             next()
-                    //             return
-                    //         }
-                    //         delete httpTokenCache[token]
-                    //     }
-                    //     const query = {
-                    //         path: req.path
-                    //     }
-                    //     try {
-                    //         await client.get(options.projectId, {
-                    //             headers: {
-                    //                 authorization: `Bearer ${token}`
-                    //             },
-                    //             searchParams: query
-                    //         })
-                    //         httpTokenCache[token] = { age: Date.now() }
-                    //         next()
-                    //     } catch (err) {
-                    //         // console.log(err)
-                    //         const error = new Error('Failed to check token')
-                    //         error.status = 401
-                    //         next(error)
-                    //     }
+                    } else if (req.get('Authorization')?.startsWith('Bearer')) {
+                        // We should include the Device ID and the path along with the token
+                        // to be checked to allow scoping tokens
+                        const token = req.get('Authorization').split(' ')[1]
+                        const cacheHit = httpTokenCache[token]
+                        if (cacheHit) {
+                            const age = (Date.now() - cacheHit.age) / 1000
+                            if (age < 300) {
+                                next()
+                                return
+                            }
+                            delete httpTokenCache[token]
+                        }
+                        const query = {
+                            path: req.path
+                        }
+                        try {
+                            await client.get(options.deviceId, {
+                                headers: {
+                                    authorization: `Bearer ${token}`
+                                },
+                                searchParams: query
+                            })
+                            console.log(' -> token valid')
+                            httpTokenCache[token] = { age: Date.now() }
+                            next()
+                        } catch (err) {
+                            // console.log(err)
+                            const error = new Error('Failed to check token')
+                            error.status = 401
+                            next(error)
+                        }
                     } else {
                         req.session.redirectTo = req.originalUrl
                         passport.authenticate('FlowFuse', { session: false })(req, res, next)
@@ -131,7 +131,7 @@ module.exports = {
 
         // need to decide on the path here
         client = got.extend({
-            prefixUrl: `${options.forgeURL}/account/check/http`,
+            prefixUrl: `${options.forgeURL}/account/check/http:device`,
             headers: {
                 'user-agent': 'FlowFuse HTTP Node Auth'
             },

--- a/lib/template/template-settings.js
+++ b/lib/template/template-settings.js
@@ -238,6 +238,7 @@ if (settings.flowforge.httpNodeAuth?.user && settings.flowforge.httpNodeAuth?.pa
         baseURL: 'https://example.com/',
         forgeURL: settings.flowforge.forgeURL,
         teamID: settings.flowforge.teamID,
+        deviceId: settings.flowforge.deviceId,
         clientID: settings.flowforge.httpNodeAuth.clientID,
         clientSecret: settings.flowforge.httpNodeAuth.clientSecret
     })


### PR DESCRIPTION
This is the final part of https://github.com/FlowFuse/flowfuse/issues/6594 - enabling HTTP Bearer token support to remote instances.

The code here is identical to that used by hosted instances.

I have tested against https://github.com/FlowFuse/flowfuse/pull/7579 (branch: `7566-device-token-ui`) - note it requires setting Device Agent version to 4.0.0 in its package.json. I've held off including that change in this PR to not confuse matters.