### PR TITLE
feat(installer): Set default Node runtime to `22.23.0`

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -38,7 +38,7 @@ powershell -c Unblock-File -Path .\flowfuse-device-agent-installer.exe
 |------|--------|---------|-------------|
 | `--otc` | `-o` | *optional* | FlowFuse one time code for authentication (optional for interactive installation) |
 | `--url` | `-u` | `https://app.flowfuse.com` | FlowFuse URL |
-| `--nodejs-version` | `-n` | `20.19.1` | Node.js version to install (minimum) |
+| `--nodejs-version` | `-n` | `22.23.0` | Node.js version to install (minimum) |
 | `--agent-version` | `-a` | `latest` | Device agent version to install/update to |
 | `--service-user` | `-s` | `flowfuse` | Username for the service account (linux/macos)|
 | `--dir` | `-d` | `/opt/flowfuse-device` (Linux/macOS) or `C:\opt\flowfuse-device` (Windows) | Installation directory for the device agent |
@@ -57,7 +57,7 @@ powershell -c Unblock-File -Path .\flowfuse-device-agent-installer.exe
 ./flowfuse-device-agent-installer --otc ONE_TIME_CODE
 
 # Install with custom settings
-./flowfuse-device-agent-installer --otc ONE_TIME_CODE --url https://your-flowfuse-instance.com --nodejs-version 20.19.1
+./flowfuse-device-agent-installer --otc ONE_TIME_CODE --url https://your-flowfuse-instance.com --nodejs-version 22.23.0
 
 # Install in non-default directory and port
 ./flowfuse-device-agent-installer --otc ONE_TIME_CODE --dir /custom/dir --port 1882
@@ -132,7 +132,7 @@ sc.exe query flowfuse-device-agent-<port>
 To update Node.js, you can specify the `--update-nodejs` flag with the desired version:
 
 ```bash
-./flowfuse-device-agent-installer --update-nodejs --nodejs-version 20.19.1
+./flowfuse-device-agent-installer --update-nodejs --nodejs-version 22.23.0
 ```
 
 Specifying `--update-nodejs` flag without a version will pick the default version defined in the installer.

--- a/installer/go/main.go
+++ b/installer/go/main.go
@@ -29,7 +29,7 @@ var (
 )
 
 func init() {
-	pflag.StringVarP(&nodeVersion, "nodejs-version", "n", "20.19.1", "Node.js version to install (minimum)")
+	pflag.StringVarP(&nodeVersion, "nodejs-version", "n", "22.23.0", "Node.js version to install (minimum)")
 	pflag.StringVarP(&agentVersion, "agent-version", "a", "latest", "Device agent version to install/update to")
 	pflag.StringVarP(&serviceUsername, "service-user", "s", "flowfuse", "Username for the service account")
 	pflag.StringVarP(&flowfuseURL, "url", "u", "https://app.flowfuse.com", "FlowFuse URL")


### PR DESCRIPTION
## Description

This pull request updates the default Node runtime version delivered by the Device Agent Installer to `22.23.0`.

## Related Issue(s)

Closes https://github.com/FlowFuse/device-agent/issues/644

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

