### PR TITLE
fix: Ensure correct theme name choice for nr5 and legacy versions

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -248,18 +248,30 @@ class Launcher {
             }
         }
 
-        // Mirror the NR5+ theme gate from nr-launcher's runtimeSettings.js.
+        // Ensure the theme is compatible with the Node-RED version.
         const storedTheme = this.config.theme || 'forge-light'
         const snapshotNRVersion = this.snapshot?.modules?.['node-red']
-        const nrMajor = parseInt((snapshotNRVersion || '0.0.0').split('.')[0], 10) || 0
+        const oldThemes = ['forge-light', 'forge-dark']
+        const newTheme = 'forge'
         let themeName = storedTheme
-        if (nrMajor >= 5) {
-            if (themeName === 'forge-light' || themeName === 'forge-dark' || themeName === 'forge') {
-                themeName = 'forge'
-            }
-        } else if (themeName === 'forge') {
-            themeName = 'forge-light'
+        let useNewThemes = false
+
+        // at the time of writing, latest is NR5.
+        if (snapshotNRVersion === 'latest' || snapshotNRVersion === 'next') {
+            useNewThemes = true
+        } else {
+            // get version info from semver
+            const nrMajor = parseInt((snapshotNRVersion || '0.0.0').split('.')[0], 10) || 0
+            useNewThemes = nrMajor >= 5
         }
+        if (useNewThemes && oldThemes.includes(themeName)) {
+            // switch old theme to new theme
+            themeName = newTheme
+        } else if (!useNewThemes && themeName === newTheme) {
+            // switch new theme to old theme
+            themeName = oldThemes[0]
+        }
+
         const assistant = {
             enabled: this.settings?.assistant?.enabled || false, // overall enable/disable
             url: `${this.config.forgeURL}/api/v1/assistant/`, // URL for the assistant service

--- a/test/unit/lib/launcher_spec.js
+++ b/test/unit/lib/launcher_spec.js
@@ -520,7 +520,48 @@ describe('Launcher', function () {
         const npmrc = await fs.readFile(path.join(config.dir, 'project', '.npmrc'))
         npmrc.toString().should.eql('// test\n')
     })
-
+    it('Keeps legacy theme name', async function () {
+        const copyOfSnapshot = JSON.parse(JSON.stringify(setup.snapshot))
+        copyOfSnapshot.modules['node-red'] = '4.2.0'
+        copyOfSnapshot.editorTheme = { theme: 'forge-dark' } // old theme
+        const launcher = newLauncher({ config: { ...config, theme: 'forge-dark' } }, null, 'projectId', copyOfSnapshot)
+        await launcher.writeSettings()
+        const setFile = await fs.readFile(path.join(config.dir, 'project', 'settings.json'))
+        const settings = JSON.parse(setFile)
+        settings.should.have.property('editorTheme')
+        settings.editorTheme.should.have.property('theme', 'forge-dark')
+    })
+    it('Updates legacy theme name for Node-RED >= 5.0.0', async function () {
+        const copyOfSnapshot = JSON.parse(JSON.stringify(setup.snapshot))
+        copyOfSnapshot.modules['node-red'] = '5.0.0'
+        copyOfSnapshot.editorTheme = { theme: 'forge-light' } // old theme name
+        const launcher = newLauncher({ config: { ...config, theme: 'forge-light' } }, null, 'projectId', copyOfSnapshot)
+        await launcher.writeSettings()
+        const setFile = await fs.readFile(path.join(config.dir, 'project', 'settings.json'))
+        const settings = JSON.parse(setFile)
+        settings.should.have.property('editorTheme')
+        settings.editorTheme.should.have.property('theme', 'forge') // updated to forge
+    })
+    it('Keeps custom theme name for Node-RED < 5.0.0', async function () {
+        const copyOfSnapshot = JSON.parse(JSON.stringify(setup.snapshot))
+        copyOfSnapshot.modules['node-red'] = '4.2.0'
+        const launcher = newLauncher({ config: { ...config, theme: 'custom-theme' } }, null, 'projectId', copyOfSnapshot)
+        await launcher.writeSettings()
+        const setFile = await fs.readFile(path.join(config.dir, 'project', 'settings.json'))
+        const settings = JSON.parse(setFile)
+        settings.should.have.property('editorTheme')
+        settings.editorTheme.should.have.property('theme', 'custom-theme') // keeps custom theme name
+    })
+    it('Keeps custom theme name for Node-RED >= 5.0.0', async function () {
+        const copyOfSnapshot = JSON.parse(JSON.stringify(setup.snapshot))
+        copyOfSnapshot.modules['node-red'] = '5.0.0'
+        const launcher = newLauncher({ config: { ...config, theme: 'custom-theme' } }, null, 'projectId', copyOfSnapshot)
+        await launcher.writeSettings()
+        const setFile = await fs.readFile(path.join(config.dir, 'project', 'settings.json'))
+        const settings = JSON.parse(setFile)
+        settings.should.have.property('editorTheme')
+        settings.editorTheme.should.have.property('theme', 'custom-theme') // keeps custom theme name
+    })
     it('Uses custom catalogue when licensed', async function () {
         const licensedConfig = {
             ...config,

--- a/test/unit/lib/launcher_spec.js
+++ b/test/unit/lib/launcher_spec.js
@@ -542,6 +542,28 @@ describe('Launcher', function () {
         settings.should.have.property('editorTheme')
         settings.editorTheme.should.have.property('theme', 'forge') // updated to forge
     })
+    it('Updates legacy theme name for Node-RED "latest"', async function () {
+        const copyOfSnapshot = JSON.parse(JSON.stringify(setup.snapshot))
+        copyOfSnapshot.modules['node-red'] = 'latest'
+        copyOfSnapshot.editorTheme = { theme: 'forge-light' } // old theme name
+        const launcher = newLauncher({ config: { ...config, theme: 'forge-light' } }, null, 'projectId', copyOfSnapshot)
+        await launcher.writeSettings()
+        const setFile = await fs.readFile(path.join(config.dir, 'project', 'settings.json'))
+        const settings = JSON.parse(setFile)
+        settings.should.have.property('editorTheme')
+        settings.editorTheme.should.have.property('theme', 'forge') // updated to forge
+    })
+    it('Updates legacy theme name for Node-RED "next"', async function () {
+        const copyOfSnapshot = JSON.parse(JSON.stringify(setup.snapshot))
+        copyOfSnapshot.modules['node-red'] = 'next'
+        copyOfSnapshot.editorTheme = { theme: 'forge-light' } // old theme name
+        const launcher = newLauncher({ config: { ...config, theme: 'forge-light' } }, null, 'projectId', copyOfSnapshot)
+        await launcher.writeSettings()
+        const setFile = await fs.readFile(path.join(config.dir, 'project', 'settings.json'))
+        const settings = JSON.parse(setFile)
+        settings.should.have.property('editorTheme')
+        settings.editorTheme.should.have.property('theme', 'forge') // updated to forge
+    })
     it('Keeps custom theme name for Node-RED < 5.0.0', async function () {
         const copyOfSnapshot = JSON.parse(JSON.stringify(setup.snapshot))
         copyOfSnapshot.modules['node-red'] = '4.2.0'


### PR DESCRIPTION
## Description

This pull request updates how the theme name is selected and stored in the `Launcher` class to ensure compatibility with different Node-RED versions. It also adds comprehensive tests to verify the correct theme is used or migrated based on the version. The main focus is to ensure that legacy theme names are updated to the new theme name for Node-RED 5.0.0 and above (or for special version tags like "latest" and "next"), while preserving custom or legacy themes for older versions.

**Theme compatibility logic:**

- Updated the theme selection logic in `lib/launcher.js` to automatically convert legacy theme names (`forge-light`, `forge-dark`) to the new theme name (`forge`) when running Node-RED 5.0.0 or later, or when the version is set to "latest" or "next". For older Node-RED versions, the logic ensures that the new theme name is converted back to a legacy theme if necessary.

**Test coverage improvements:**

- Added multiple tests in `test/unit/lib/launcher_spec.js` to verify:
    - Legacy theme names are kept for Node-RED < 5.0.0.
    - Legacy theme names are updated to the new theme for Node-RED >= 5.0.0, "latest", or "next".
    - Custom theme names are preserved for all Node-RED versions.

## Related Issue(s)

part of #670

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

