### PR TITLE
chore: update nr-theme dependency and general npm update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "3.9.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@flowfuse/nr-theme": "^1.10.0",
+                "@flowfuse/nr-theme": "^1.11.0",
                 "@inquirer/confirm": "^5.1.9",
                 "@inquirer/select": "^4.2.0",
                 "bytes": "^3.1.2",
@@ -258,9 +258,9 @@
             }
         },
         "node_modules/@flowfuse/nr-theme": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@flowfuse/nr-theme/-/nr-theme-1.10.0.tgz",
-            "integrity": "sha512-LIDEjDMvTAWqnAGTOaMKMeRU1xzV8CQkPli41Zq0fcK5ryV/JuJvbOlyQ/sagGmhbJozBuk/3bwYngdT1S6IaA==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@flowfuse/nr-theme/-/nr-theme-1.11.0.tgz",
+            "integrity": "sha512-C+bMluSuRABbFdZnvAigrIsbtMpXNfMDpPu7Xr/EPTz+W8eXnyCkivqf49g4UxIFUWF34QS8u8hOiP8Vasc36A==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=14.x"
@@ -7391,9 +7391,9 @@
             }
         },
         "@flowfuse/nr-theme": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@flowfuse/nr-theme/-/nr-theme-1.10.0.tgz",
-            "integrity": "sha512-LIDEjDMvTAWqnAGTOaMKMeRU1xzV8CQkPli41Zq0fcK5ryV/JuJvbOlyQ/sagGmhbJozBuk/3bwYngdT1S6IaA=="
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@flowfuse/nr-theme/-/nr-theme-1.11.0.tgz",
+            "integrity": "sha512-C+bMluSuRABbFdZnvAigrIsbtMpXNfMDpPu7Xr/EPTz+W8eXnyCkivqf49g4UxIFUWF34QS8u8hOiP8Vasc36A=="
         },
         "@humanfs/core": {
             "version": "0.19.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "author": "FlowFuse Inc.",
     "license": "Apache-2.0",
     "dependencies": {
-        "@flowfuse/nr-theme": "^1.10.0",
+        "@flowfuse/nr-theme": "^1.11.0",
         "@inquirer/confirm": "^5.1.9",
         "@inquirer/select": "^4.2.0",
         "bytes": "^3.1.2",


### PR DESCRIPTION
Update nr-theme to `^1.11` and update package-lock with a `npm update` run