### PR TITLE
chore: Ensure plugins are linted

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,6 +29,13 @@ export default [
             ...resolveIgnoresFromGitignore()
         ]
     },
+    {
+        // re-include 1st party plugin source bundled under nested node_modules because
+        // eslint's default `**/node_modules/` global ignore causes it to be skipped
+        // Note: both entries are required as eslint prunes without descending so it
+        // has to be specific enough that gitignore derived ignores don't re-add it back in.
+        ignores: ['!**/lib/plugins/node_modules', '!**/lib/plugins/node_modules/**']
+    },
     js.configs.recommended,
     ...neostandard(),
     {

--- a/lib/plugins/node_modules/@flowfuse/flowfuse-auth/httpAuthMiddleware.js
+++ b/lib/plugins/node_modules/@flowfuse/flowfuse-auth/httpAuthMiddleware.js
@@ -55,6 +55,7 @@ module.exports = {
                         passport.authenticate('FlowFuse', { session: false })(req, res, next)
                     }
                 } catch (err) {
+                    // eslint-disable-next-line no-console
                     console.log(err.stack)
                     throw err
                 }

--- a/lib/plugins/node_modules/@flowfuse/flowfuse-auth/httpAuthMiddleware.js
+++ b/lib/plugins/node_modules/@flowfuse/flowfuse-auth/httpAuthMiddleware.js
@@ -42,7 +42,6 @@ module.exports = {
                                 },
                                 searchParams: query
                             })
-                            console.log(' -> token valid')
                             httpTokenCache[token] = { age: Date.now() }
                             next()
                         } catch (err) {

--- a/lib/plugins/node_modules/@flowfuse/flowfuse-auth/strategy.js
+++ b/lib/plugins/node_modules/@flowfuse/flowfuse-auth/strategy.js
@@ -1,5 +1,4 @@
 const util = require('util')
-const url = require('url')
 const OAuth2Strategy = require('passport-oauth2')
 
 const Roles = {
@@ -37,9 +36,9 @@ util.inherits(Strategy, OAuth2Strategy)
  *    k8s, internal requests may be http, but need to be considered as https when generating the
  *    external callback url
  *  - for Devices, we don't need to do that - so the code is gone.
- * 
+ *
  * IF we attempt to DRY the auth handler between device and launcher, this difference
- * MUST be considered 
+ * MUST be considered
  */
 
 Strategy.prototype.sendAPIRequest = function (url, accessToken, done) {
@@ -60,11 +59,13 @@ Strategy.prototype.userProfile = function (accessToken, done) {
     this._oauth2.useAuthorizationHeaderforGET(true)
     this.sendAPIRequest(this.options.userInfoURL, accessToken, (err, userProfile) => {
         if (err) {
+            // eslint-disable-next-line no-console
             console.log('Authentication error:', err)
             return done(err)
         }
         this.sendAPIRequest(this.options.userTeamRoleURL, accessToken, (err, userTeamRole) => {
             if (err) {
+                // eslint-disable-next-line no-console
                 console.log('Authentication error:', err)
                 return done(err)
             }


### PR DESCRIPTION
## Description

Add un-ignores to lint configuration so that files under `lib/plugins/node_modules/**` are picked up

## Related Issue(s)

closes #667

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

