### PR TITLE
fix: Merge catalogue and npmrc for hosted instance bound devices

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -349,7 +349,7 @@ class Launcher {
                     settings.editorTheme.palette.catalogues = this.snapshot.settings.palette.catalogue
                     // need to merge in settings catalogues and remove duplicates
                     const temp = [...(this.settings?.palette?.catalogues || []), ...(this.snapshot.settings?.palette?.catalogue || [])]
-                    settings.editorTheme.palette.catalogue = temp.filter((item, pos, self) => {
+                    settings.editorTheme.palette.catalogues = temp.filter((item, pos, self) => {
                         return self.indexOf(item) === pos
                     })
                 }

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -348,7 +348,7 @@ class Launcher {
                 if (this.snapshot?.settings?.palette?.catalogue !== undefined) {
                     settings.editorTheme.palette.catalogues = this.snapshot.settings.palette.catalogue
                     // need to merge in settings catalogues and remove duplicates
-                    const temp = [...(this.settings.palette.catalogues || []), ...(this.snapshot.settings.palette.catalogue || [])]
+                    const temp = [...(this.settings?.palette?.catalogues || []), ...(this.snapshot.settings?.palette?.catalogue || [])]
                     settings.editorTheme.palette.catalogue = temp.filter((item, pos, self) => {
                         return self.indexOf(item) === pos
                     })
@@ -477,7 +477,7 @@ class Launcher {
         if (this.project) {
             if (this.snapshot.settings?.palette?.npmrc || this.settings.palette.npmrc) {
                 // need to merge settings and snapshot
-                const allRows = [...(this.snapshot.settings.palette.npmrc || '').split('\n'), ...(this.settings.palette.npmrc || '').split('\n')]
+                const allRows = [...(this.snapshot.settings?.palette?.npmrc || '').split('\n'), ...(this.settings?.palette?.npmrc || '').split('\n')]
                 const noDupes = allRows.filter((item, pos, self) => {
                     return self.indexOf(item) === pos
                 })

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -347,6 +347,11 @@ class Launcher {
             if (this.project) {
                 if (this.snapshot?.settings?.palette?.catalogue !== undefined) {
                     settings.editorTheme.palette.catalogues = this.snapshot.settings.palette.catalogue
+                    // need to merge in settings catalogues and remove duplicates
+                    const temp = [...(this.settings.palette.catalogues || []), ...(this.snapshot.settings.palette.catalogue || [])]
+                    settings.editorTheme.palette.catalogue = temp.filter((item, pos, self) => {
+                        return self.indexOf(item) === pos
+                    })
                 }
             } else if (this.application) {
                 if (this.settings.palette?.catalogues) {
@@ -470,8 +475,13 @@ class Launcher {
      */
     async writeNPMRCFile () {
         if (this.project) {
-            if (this.snapshot.settings?.palette?.npmrc) {
-                await fs.writeFile(this.files.npmrc, this.snapshot.settings.palette.npmrc)
+            if (this.snapshot.settings?.palette?.npmrc || this.settings.palette.npmrc) {
+                // need to merge settings and snapshot
+                const allRows = [...(this.snapshot.settings.palette.npmrc || '').split('\n'), ...(this.settings.palette.npmrc || '').split('\n')]
+                const noDupes = allRows.filter((item, pos, self) => {
+                    return self.indexOf(item) === pos
+                })
+                await fs.writeFile(this.files.npmrc, noDupes.join('\n'))
             } else {
                 if (existsSync(this.files.npmrc)) {
                     await fs.rm(this.files.npmrc)


### PR DESCRIPTION
fixes #677

## Description

<!-- Describe your changes in detail -->
If this is a hosted instance bound device then it merges the settings and the snapshot npmrc and catalogue lists.

This means devices shold see certified nodes if enabled

We merge both and remove duplicate entries.

Will need a device agent release to apply.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#677

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

