### PR TITLE
fix: Ensure MCP server-side sessions are terminated

### DIFF
--- a/lib/mcp.js
+++ b/lib/mcp.js
@@ -260,7 +260,7 @@ class MCP {
 
     /**
      * Connect a fresh MCP client to the given (already-normalised) endpoint spec.
-     * Caller is responsible for `client.close()` when finished.
+     * Caller is responsible for calling {@link _disconnect} when finished.
      * @param {McpEndpoint} endpoint
      * @returns {Promise<McpClient>} a connected MCP Client instance
      */
@@ -272,6 +272,31 @@ class MCP {
         const client = new Client({ name: CLIENT_NAME, version: CLIENT_VERSION })
         await client.connect(transport)
         return client
+    }
+
+    /**
+     * Tear down a connected client, terminating the server-side session first.
+     *
+     * The agent opens a fresh session for every operation, so it must also close
+     * them: the SDK client's `close()` only aborts the local connection — it does
+     * NOT send the HTTP DELETE that terminates the session on the server. Without
+     * an explicit `terminateSession()`, server-side sessions accumulate (the MCP
+     * host has no idle reaper), and every subsequent connection re-runs its
+     * registration pass across all of them. So we terminate, then close.
+     * @param {McpClient} [client]
+     */
+    async _disconnect (client) {
+        if (!client) {
+            return
+        }
+        try {
+            /** @type {StreamableHTTPClientTransport} */
+            const transport = client.transport
+            await transport?.terminateSession?.()
+        } catch (_) { /* server may not support DELETE; fall through to close */ }
+        try {
+            await client.close()
+        } catch (_) { /* ignore */ }
     }
 
     async _getEndpointFeatures (/** @type {McpEndpoint} */ endpoint) {
@@ -323,11 +348,7 @@ class MCP {
             warn(`Failed to query MCP endpoint '${endpoint.key}': ${err.message}`)
             features.error = err.message
         } finally {
-            if (client) {
-                try {
-                    await client.close()
-                } catch (_) { /* ignore */ }
-            }
+            await this._disconnect(client)
         }
         return features
     }
@@ -416,11 +437,7 @@ class MCP {
             const response = await client.callTool({ name, arguments: input || {} })
             return response
         } finally {
-            if (client) {
-                try {
-                    await client.close()
-                } catch (_) { /* ignore */ }
-            }
+            await this._disconnect(client)
         }
     }
 
@@ -449,11 +466,7 @@ class MCP {
             const response = await client.readResource({ uri })
             return response
         } finally {
-            if (client) {
-                try {
-                    await client.close()
-                } catch (_) { /* ignore */ }
-            }
+            await this._disconnect(client)
         }
     }
 


### PR DESCRIPTION
## Description

Refactors the client disconnect logic in the `MCP` class to ensure that server-side sessions are properly terminated, preventing resource leaks.


* Added a new `_disconnect` method to the `MCP` class, which first sends an HTTP DELETE request to terminate the server-side session (if supported), then closes the client connection. This prevents server-side session accumulation.
* Updated all code paths in the `MCP` class that previously called `client.close()` directly (in `_getEndpointFeatures`, tool invocation, and resource reading) to use the new `_disconnect` method instead. [[1]](diffhunk://#diff-70cba48263969fcef28ec9cf7799cc10a001dc8f02dfe8699b03a96ea9c2ba9bL326-R351) [[2]](diffhunk://#diff-70cba48263969fcef28ec9cf7799cc10a001dc8f02dfe8699b03a96ea9c2ba9bL419-R440) [[3]](diffhunk://#diff-70cba48263969fcef28ec9cf7799cc10a001dc8f02dfe8699b03a96ea9c2ba9bL452-R469)



## Related Issue(s)

closes #688 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

