### PR TITLE
fix: Show actual error when connecting to a platform

### DIFF
--- a/lib/AgentManager.js
+++ b/lib/AgentManager.js
@@ -269,9 +269,11 @@ class AgentManager {
 
             // Get the local IP address / MAC / Hostname of the device to generate a value for the agentHost field
             const anEndpoint = new URL('/api/v1/settings/', provisioningConfig.forgeURL)
-            const { host, ip, forgeOk } = await this._getDeviceInfo(anEndpoint)
+            const { host, ip, forgeOk, statusCode, _error } = await this._getDeviceInfo(anEndpoint)
             if (!forgeOk) {
-                throw new Error('Unable to connect to the FlowFuse Platform')
+                const reason = _error ? _error.toString() : `unexpected response status ${statusCode ?? 'none'}`
+                debug(`Connectivity check to ${anEndpoint.href} failed: ${reason}`)
+                throw new Error(`Unable to connect to the FlowFuse Platform (${reason})`)
             }
 
             // Instruct platform to re-generate credentials for this device, passing in the agentHost field and the quickConnect flag
@@ -431,6 +433,7 @@ class AgentManager {
                     result._error = _error
                     forgeCheck = _error.response
                 }
+                result.statusCode = forgeCheck?.statusCode
                 if (token) {
                     result.forgeOk = [200, 204].includes(forgeCheck?.statusCode)
                 } else {


### PR DESCRIPTION
## Description

This pull request improves error verbosity when a device is unable to communicate with the FlowFuse Platform by surfacing the exact error to the user.

## Related Issue(s)

Closes https://github.com/FlowFuse/device-agent/issues/695

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

