### PR TITLE
feat(installer): Add possibility to provide custom CA bundle certificate

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -44,6 +44,7 @@ powershell -c Unblock-File -Path .\flowfuse-device-agent-installer.exe
 | `--dir` | `-d` | `/opt/flowfuse-device` (Linux/macOS) or `C:\opt\flowfuse-device` (Windows) | Installation directory for the device agent |
 | `--port` | `-p` | `1880` | TCP port for the device agent (1025–65535). Service name is suffixed with the port, e.g., `flowfuse-device-agent-1880`. |
 | `--uninstall` | | `false` | Uninstall the device agent |
+| `--ca-cert` | | *optional* | Path to a CA certificate bundle (PEM) the Device Agent should trust |
 | `--update-nodejs` | | `false` | Update bundled Node.js to specified version |
 | `--update-agent` | | `false` | Update the Device Agent package to specified version |
 | `--debug` | | `false` | Enable debug logging |
@@ -64,6 +65,9 @@ powershell -c Unblock-File -Path .\flowfuse-device-agent-installer.exe
 
 # Enable debug logging
 ./flowfuse-device-agent-installer --otc ONE_TIME_CODE --debug
+
+# Install with a custom CA certificate bundle
+./flowfuse-device-agent-installer --otc ONE_TIME_CODE --ca-cert /path/to/ca-bundle.pem
 
 # Uninstall the device agent
 ./flowfuse-device-agent-installer --uninstall

--- a/installer/README.md
+++ b/installer/README.md
@@ -44,7 +44,7 @@ powershell -c Unblock-File -Path .\flowfuse-device-agent-installer.exe
 | `--dir` | `-d` | `/opt/flowfuse-device` (Linux/macOS) or `C:\opt\flowfuse-device` (Windows) | Installation directory for the device agent |
 | `--port` | `-p` | `1880` | TCP port for the device agent (1025–65535). Service name is suffixed with the port, e.g., `flowfuse-device-agent-1880`. |
 | `--uninstall` | | `false` | Uninstall the device agent |
-| `--ca-cert` | | *optional* | Path to a CA certificate bundle (PEM) the Device Agent should trust |
+| `--ca-cert` | | *optional* | Path to a CA certificate bundle (PEM) the Device Agent should trust. Applies to installation phase only. |
 | `--update-nodejs` | | `false` | Update bundled Node.js to specified version |
 | `--update-agent` | | `false` | Update the Device Agent package to specified version |
 | `--debug` | | `false` | Enable debug logging |

--- a/installer/go/cmd/install.go
+++ b/installer/go/cmd/install.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/flowfuse/device-agent-installer/pkg/config"
@@ -40,7 +41,7 @@ import (
 //   - error: An error object if any step of the installation fails, nil otherwise
 //
 // The function logs detailed information about each step of the process.
-func Install(nodeVersion, agentVersion, url, otc, customWorkDir string, update bool, port int) error {
+func Install(nodeVersion, agentVersion, url, otc, customWorkDir string, update bool, port int, caCertPath string) error {
 	logger.LogFunctionEntry("Install", map[string]interface{}{
 		"nodeVersion":   nodeVersion,
 		"agentVersion":  agentVersion,
@@ -68,6 +69,30 @@ func Install(nodeVersion, agentVersion, url, otc, customWorkDir string, update b
 		return fmt.Errorf("failed to create working directory: %w", err)
 	}
 	logger.Debug("Working directory created at: %s", workDir)
+
+	// Resolve and install the custom CA bundle (if any) before Node.js/npm/OTC steps,
+	// so both the setup commands and the long-running service trust it.
+	// Precedence: --ca-cert flag, then NODE_EXTRA_CA_CERTS env, then the value stored
+	// from a previous install (so a bare reinstall keeps CA trust without re-passing it).
+	caSrc := caCertPath
+	if caSrc == "" {
+		caSrc = os.Getenv("NODE_EXTRA_CA_CERTS")
+	}
+	if caSrc == "" {
+		if prev, cfgErr := config.LoadConfig(workDir); cfgErr == nil {
+			caSrc = prev.NodeExtraCACerts
+		}
+	}
+	caCertDest, err := utils.InstallCACertificate(caSrc, workDir)
+	if err != nil {
+		logger.Error("Failed to install CA certificate: %v", err)
+		logger.LogFunctionExit("Install", nil, err)
+		return fmt.Errorf("failed to install CA certificate: %w", err)
+	}
+	if caCertDest != "" {
+		os.Setenv("NODE_EXTRA_CA_CERTS", caCertDest)
+		logger.Debug("Using custom CA certificate bundle: %s", caCertDest)
+	}
 
 	// Check/install Node.js
 	logger.Info("Checking Node.js installation...")
@@ -106,7 +131,7 @@ func Install(nodeVersion, agentVersion, url, otc, customWorkDir string, update b
 	}
 
 	logger.Info("Configuring FlowFuse Device Agent to run as system service...")
-	if err := service.Install(serviceName, workDir, port); err != nil {
+	if err := service.Install(serviceName, workDir, port, caCertDest); err != nil {
 		logger.Error("Service setup failed: %v", err)
 		logger.LogFunctionExit("Install", nil, err)
 		return fmt.Errorf("service setup failed: %w", err)
@@ -133,11 +158,12 @@ func Install(nodeVersion, agentVersion, url, otc, customWorkDir string, update b
 		}
 	}
 	cfg := &config.InstallerConfig{
-		ServiceUsername: utils.ServiceUsername,
-		ServiceName:     serviceName,
-		NodeVersion:     nodeVersion,
-		AgentVersion:    agentVersion,
-		Port:            port,
+		ServiceUsername:  utils.ServiceUsername,
+		ServiceName:      serviceName,
+		NodeVersion:      nodeVersion,
+		AgentVersion:     agentVersion,
+		Port:             port,
+		NodeExtraCACerts: caCertDest,
 	}
 	logger.Debug("Saving configuration: %+v", cfg)
 	if err := config.SaveConfig(cfg, workDir); err != nil {

--- a/installer/go/main.go
+++ b/installer/go/main.go
@@ -18,6 +18,7 @@ var (
 	nodeVersion         string
 	serviceUsername     string
 	installDir          string
+	caCertPath          string
 	instVersion         string
 	showVersion         bool
 	help                bool
@@ -36,6 +37,7 @@ func init() {
 	pflag.StringVarP(&flowfuseOneTimeCode, "otc", "o", "", "FlowFuse one time code for authentication (optional for interactive installation)")
 	pflag.StringVarP(&installDir, "dir", "d", "", "Custom installation directory (default: /opt/flowfuse-device on Unix, c:\\opt\\flowfuse-device on Windows)")
 	pflag.IntVarP(&port, "port", "p", 1880, "TCP port for the device agent (1-65535)")
+	pflag.StringVar(&caCertPath, "ca-cert", "", "Path to a CA certificate bundle (PEM) the Device Agent should trust")
 	pflag.BoolVarP(&showVersion, "version", "v", false, "Display installer version")
 	pflag.BoolVarP(&help, "help", "h", false, "Display help information")
 	pflag.BoolVar(&uninstall, "uninstall", false, "Uninstall the device agent")
@@ -54,8 +56,8 @@ func init() {
 		fmt.Print("\n")
 		fmt.Println("Usage:")
 		fmt.Println("  Installation:")
-		fmt.Printf("    %s --otc <one-time-code> [--agent-version <version>] [--nodejs-version <version>] [--dir <custom-dir>] [--port <n>]\n", exeName)
-		fmt.Printf("    %s [--agent-version <version>] [--nodejs-version <version>] [--dir <custom-dir>] [--port <n>] (interactive mode)\n", exeName)
+		fmt.Printf("    %s --otc <one-time-code> [--agent-version <version>] [--nodejs-version <version>] [--dir <custom-dir>] [--port <n>] [--ca-cert <path>]\n", exeName)
+		fmt.Printf("    %s [--agent-version <version>] [--nodejs-version <version>] [--dir <custom-dir>] [--port <n>] [--ca-cert <path>] (interactive mode)\n", exeName)
 		fmt.Println("  Update:")
 		fmt.Printf("    %s --update-agent [--agent-version <version>]\n", exeName)
 		fmt.Printf("    %s --update-nodejs [--nodejs-version <version>]\n", exeName)
@@ -94,8 +96,8 @@ func main() {
 	}
 
 	// Log startup information
-	logger.Debug("Command line arguments: node=%s, agent=%s, user=%s, url=%s, debug=%v, customInstallDir=%s, port=%d",
-		nodeVersion, agentVersion, serviceUsername, flowfuseURL, debugMode, installDir, port)
+	logger.Debug("Command line arguments: node=%s, agent=%s, user=%s, url=%s, debug=%v, customInstallDir=%s, port=%d, caCert=%s",
+		nodeVersion, agentVersion, serviceUsername, flowfuseURL, debugMode, installDir, port, caCertPath)
 	operatingSystem, architecture := utils.GetOSDetails()
 	logger.Debug("Detected system: %s, detected architecture: %s", operatingSystem, architecture)
 
@@ -130,7 +132,7 @@ func main() {
 		err = cmd.Update(agentVersion, nodeVersion, installDir, updateAgent, updateNode)
 	} else {
 		logger.Info("Installing FlowFuse Device Agent...")
-		err = cmd.Install(nodeVersion, agentVersion, flowfuseURL, flowfuseOneTimeCode, installDir, false, port)
+		err = cmd.Install(nodeVersion, agentVersion, flowfuseURL, flowfuseOneTimeCode, installDir, false, port, caCertPath)
 	}
 
 	if err != nil {

--- a/installer/go/pkg/config/config.go
+++ b/installer/go/pkg/config/config.go
@@ -19,6 +19,9 @@ type InstallerConfig struct {
 	AgentVersion    string `json:"agentVersion"`
 	NodeVersion     string `json:"nodeVersion"`
 	Port            int    `json:"port"`
+	// NodeExtraCACerts is the in-workdir path to the installed custom CA bundle,
+	// re-applied on reinstall so CA trust survives without re-passing --ca-cert.
+	NodeExtraCACerts string `json:"nodeExtraCACerts,omitempty"`
 }
 
 // GetConfigPath returns the path to the installer configuration file.
@@ -183,6 +186,8 @@ func UpdateConfigField(fieldName, value, customWorkDir string) error {
 	case "port":
 		port, _ := strconv.Atoi(value)
 		cfg.Port = port
+	case "nodeExtraCACerts":
+		cfg.NodeExtraCACerts = value
 	default:
 		logger.LogFunctionExit("UpdateConfigField", "error", fmt.Errorf("unknown field name: %s", fieldName))
 		return fmt.Errorf("unknown field name: %s", fieldName)

--- a/installer/go/pkg/nodejs/deviceagent.go
+++ b/installer/go/pkg/nodejs/deviceagent.go
@@ -15,6 +15,11 @@ import (
 
 const packageName = "@flowfuse/device-agent"
 
+// preserveEnv is the sudo --preserve-env list used for node/npm/agent invocations.
+// NODE_EXTRA_CA_CERTS (set from --ca-cert) is forwarded so custom-CA setups work;
+// sudo silently ignores it when unset.
+const preserveEnv = "--preserve-env=PATH,NODE_EXTRA_CA_CERTS"
+
 // InstallDeviceAgent installs the FlowFuse Device Agent with the specified version
 // to the given base directory. It requires Node.js to be already installed.
 // The function will:
@@ -65,7 +70,7 @@ func InstallDeviceAgent(version, baseDir string, update bool) error {
 	npmPrefix := fmt.Sprintf("npm_config_prefix=%s", nodeBaseDir)
 	switch runtime.GOOS {
 	case "linux", "darwin":
-		installCmd = exec.Command("sudo", "--preserve-env=PATH", "-u", serviceUser, npmBinPath, "install", "-g", "--cache", filepath.Join(nodeBaseDir, ".npm-cache"), packageName)
+		installCmd = exec.Command("sudo", preserveEnv, "-u", serviceUser, npmBinPath, "install", "-g", "--cache", filepath.Join(nodeBaseDir, ".npm-cache"), packageName)
 		env := os.Environ()
 		installCmd.Env = append(env, npmPrefix, newPath)
 	case "windows":
@@ -135,7 +140,7 @@ func GetLatestDeviceAgentVersion(baseDir string) (string, error) {
 
 	switch runtime.GOOS {
 	case "linux", "darwin":
-		viewCmd = exec.Command("sudo", "--preserve-env=PATH", "-u", serviceUser, npmBinPath, "--cache", filepath.Join(nodeBaseDir, ".npm-cache"), "view", packageName, "version", "--no-update-notifier", "-silent")
+		viewCmd = exec.Command("sudo", preserveEnv, "-u", serviceUser, npmBinPath, "--cache", filepath.Join(nodeBaseDir, ".npm-cache"), "view", packageName, "version", "--no-update-notifier", "-silent")
 		env := os.Environ()
 		viewCmd.Env = append(env, newPath)
 	case "windows":
@@ -231,7 +236,7 @@ func UninstallDeviceAgent(baseDir string) error {
 	npmPrefix := fmt.Sprintf("npm_config_prefix=%s", nodeBaseDir)
 	switch runtime.GOOS {
 	case "linux", "darwin":
-		uninstallCmd = exec.Command("sudo", "--preserve-env=PATH", "-u", serviceUser, npmBinPath, "uninstall", "-g", packageName)
+		uninstallCmd = exec.Command("sudo", preserveEnv, "-u", serviceUser, npmBinPath, "uninstall", "-g", packageName)
 		env := os.Environ()
 		uninstallCmd.Env = append(env, npmPrefix, newPath)
 	case "windows":
@@ -312,7 +317,7 @@ func ConfigureDeviceAgent(url, token, baseDir string, port int) (string, bool, e
 		var configureCmd *exec.Cmd
 		switch runtime.GOOS {
 		case "linux", "darwin":
-			configureCmd = exec.Command("sudo", "--preserve-env=PATH", deviceAgentPath, "-o", token, "-u", url, "--dir", baseDir, "--port", fmt.Sprintf("%d", port), "--otc-no-start", "--installer-mode")
+			configureCmd = exec.Command("sudo", preserveEnv, deviceAgentPath, "-o", token, "-u", url, "--dir", baseDir, "--port", fmt.Sprintf("%d", port), "--otc-no-start", "--installer-mode")
 			env := os.Environ()
 			configureCmd.Dir = baseDir
 			configureCmd.Env = append(env, newPath)

--- a/installer/go/pkg/service/darwin.go
+++ b/installer/go/pkg/service/darwin.go
@@ -22,6 +22,7 @@ type LaunchdConfig struct {
 	User       string
 	NodeBinDir string
 	Port       int
+	NodeExtraCACerts string // Optional custom CA bundle path (NODE_EXTRA_CA_CERTS)
 }
 
 // newsyslogConfig holds the data for the newsyslog configuration
@@ -86,7 +87,7 @@ func setNewsyslogConfPath(label string) string {
 //
 // Returns:
 //   - error: nil if successful, otherwise an error explaining what went wrong
-func InstallDarwin(serviceName, workDir string, port int) error {
+func InstallDarwin(serviceName, workDir string, port int, caCertPath string) error {
 	serviceUser := utils.ServiceUsername
 	label := setLabel(serviceName)
 
@@ -106,13 +107,14 @@ func InstallDarwin(serviceName, workDir string, port int) error {
 	errorLogFilePath := filepath.Join(logDir, "flowfuse-device-agent-error.log")
 
 	config := LaunchdConfig{
-		Label:      label,
-		WorkDir:    workDir,
-		LogFile:    logFilePath,
-		ErrorFile:  errorLogFilePath,
-		User:       serviceUser,
-		NodeBinDir: nodejs.GetNodeBinDir(),
-		Port:       port,
+		Label:            label,
+		WorkDir:          workDir,
+		LogFile:          logFilePath,
+		ErrorFile:        errorLogFilePath,
+		User:             serviceUser,
+		NodeBinDir:       nodejs.GetNodeBinDir(),
+		Port:             port,
+		NodeExtraCACerts: caCertPath,
 	}
 
 	tmpl, err := template.New("launchd").Parse(launchdTemplate)

--- a/installer/go/pkg/service/linux.go
+++ b/installer/go/pkg/service/linux.go
@@ -14,13 +14,14 @@ import (
 
 // ServiceConfig holds the data for the service template
 type ServiceConfig struct {
-	User         string
-	WorkDir      string
-	NodeBinDir   string
-	ServiceName  string // Used for sysvinit scripts
-	LogFile      string // Log file path for openrc scripts
-	ErrorLogFile string // Error log file path for openrc scripts
-	Port         int
+	User             string
+	WorkDir          string
+	NodeBinDir       string
+	ServiceName      string // Used for sysvinit scripts
+	LogFile          string // Log file path for openrc scripts
+	ErrorLogFile     string // Error log file path for openrc scripts
+	Port             int
+	NodeExtraCACerts string // Optional custom CA bundle path (NODE_EXTRA_CA_CERTS)
 }
 
 // IsSystemd returns true if the system uses systemd, false otherwise
@@ -75,7 +76,7 @@ func IsOpenRC() bool {
 //
 // Returns:
 //   - error: nil if successful, otherwise an error describing what went wrong
-func InstallLinux(serviceName, workDir string, port int) error {
+func InstallLinux(serviceName, workDir string, port int, caCertPath string) error {
 	logger.LogFunctionEntry("InstallLinux", map[string]interface{}{
 		"serviceName": serviceName,
 		"workDir":     workDir,
@@ -84,11 +85,11 @@ func InstallLinux(serviceName, workDir string, port int) error {
 	defer logger.LogFunctionExit("InstallLinux", nil, nil)
 
 	if IsSystemd() {
-		return InstallSystemd(serviceName, workDir, port)
+		return InstallSystemd(serviceName, workDir, port, caCertPath)
 	} else if IsSysVInit() {
-		return InstallSysVInit(serviceName, workDir, port)
+		return InstallSysVInit(serviceName, workDir, port, caCertPath)
 	} else if IsOpenRC() {
-		return InstallOpenRC(serviceName, workDir, port)
+		return InstallOpenRC(serviceName, workDir, port, caCertPath)
 	} else {
 		logger.Error("No supported init system found (systemd or sysvinit)")
 		return fmt.Errorf("no supported init system found (systemd or sysvinit)")
@@ -108,7 +109,7 @@ func InstallLinux(serviceName, workDir string, port int) error {
 //
 // Returns:
 //   - error: nil if successful, otherwise an error describing what went wrong
-func InstallSystemd(serviceName, workDir string, port int) error {
+func InstallSystemd(serviceName, workDir string, port int, caCertPath string) error {
 	logger.LogFunctionEntry("InstallSystemd", map[string]interface{}{
 		"serviceName": serviceName,
 		"workDir":     workDir,
@@ -116,10 +117,11 @@ func InstallSystemd(serviceName, workDir string, port int) error {
 	defer logger.LogFunctionExit("InstallSystemd", nil, nil)
 
 	config := ServiceConfig{
-		User:       utils.ServiceUsername,
-		WorkDir:    workDir,
-		NodeBinDir: nodejs.GetNodeBinDir(),
-		Port:       port,
+		User:             utils.ServiceUsername,
+		WorkDir:          workDir,
+		NodeBinDir:       nodejs.GetNodeBinDir(),
+		Port:             port,
+		NodeExtraCACerts: caCertPath,
 	}
 
 	serviceFilePath := "/etc/systemd/system/" + serviceName + ".service"
@@ -182,7 +184,7 @@ func InstallSystemd(serviceName, workDir string, port int) error {
 //   - Copy the service script to /etc/init.d/
 //   - Set permissions on the service script
 //   - Enable the service
-func InstallSysVInit(serviceName, workDir string, port int) error {
+func InstallSysVInit(serviceName, workDir string, port int, caCertPath string) error {
 	logger.LogFunctionEntry("InstallSysVInit", map[string]interface{}{
 		"serviceName": serviceName,
 		"workDir":     workDir,
@@ -190,11 +192,12 @@ func InstallSysVInit(serviceName, workDir string, port int) error {
 	defer logger.LogFunctionExit("InstallSysVInit", nil, nil)
 
 	config := ServiceConfig{
-		User:        utils.ServiceUsername,
-		WorkDir:     workDir,
-		NodeBinDir:  nodejs.GetNodeBinDir(),
-		ServiceName: serviceName,
-		Port:        port,
+		User:             utils.ServiceUsername,
+		WorkDir:          workDir,
+		NodeBinDir:       nodejs.GetNodeBinDir(),
+		ServiceName:      serviceName,
+		Port:             port,
+		NodeExtraCACerts: caCertPath,
 	}
 
 	serviceFilePath := "/etc/init.d/" + serviceName
@@ -258,7 +261,7 @@ func InstallSysVInit(serviceName, workDir string, port int) error {
 //
 // Returns:
 //   - error: nil if successful, otherwise an error describing what went wrong
-func InstallOpenRC(serviceName, workDir string, port int) error {
+func InstallOpenRC(serviceName, workDir string, port int, caCertPath string) error {
 	logger.LogFunctionEntry("InstallOpenRC", map[string]interface{}{
 		"serviceName": serviceName,
 		"workDir":     workDir,
@@ -282,12 +285,13 @@ func InstallOpenRC(serviceName, workDir string, port int) error {
 	errorLogFilePath := filepath.Join(logDir, fmt.Sprintf("%s-error.log", serviceName))
 
 	config := ServiceConfig{
-		User:         utils.ServiceUsername,
-		WorkDir:      workDir,
-		NodeBinDir:   nodejs.GetNodeBinDir(),
-		LogFile:      logFilePath,
-		ErrorLogFile: errorLogFilePath,
-		Port:         port,
+		User:             utils.ServiceUsername,
+		WorkDir:          workDir,
+		NodeBinDir:       nodejs.GetNodeBinDir(),
+		LogFile:          logFilePath,
+		ErrorLogFile:     errorLogFilePath,
+		Port:             port,
+		NodeExtraCACerts: caCertPath,
 	}
 
 	serviceFilePath := "/etc/init.d/" + serviceName

--- a/installer/go/pkg/service/service.go
+++ b/installer/go/pkg/service/service.go
@@ -16,15 +16,15 @@ import (
 //
 // Returns:
 //   - error: nil if successful, otherwise an error explaining what went wrong
-func Install(serviceName, workDir string, port int) error {
+func Install(serviceName, workDir string, port int, caCertPath string) error {
 	logger.Info("Installing FlowFuse Device Agent service for %s...", runtime.GOOS)
 	switch runtime.GOOS {
 	case "linux":
-		return InstallLinux(serviceName, workDir, port)
+		return InstallLinux(serviceName, workDir, port, caCertPath)
 	case "windows":
-		return InstallWindows(serviceName, workDir, port)
+		return InstallWindows(serviceName, workDir, port, caCertPath)
 	case "darwin":
-		return InstallDarwin(serviceName, workDir, port)
+		return InstallDarwin(serviceName, workDir, port, caCertPath)
 	default:
 		return fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
 	}

--- a/installer/go/pkg/service/templates.go
+++ b/installer/go/pkg/service/templates.go
@@ -15,7 +15,8 @@ WorkingDirectory={{.WorkDir}}
 
 Environment="NODE_OPTIONS=--max_old_space_size=512"
 Environment="PATH={{.NodeBinDir}}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-ExecStart=/usr/bin/env -S flowfuse-device-agent --dir {{.WorkDir}} --port {{.Port}}
+{{if .NodeExtraCACerts}}Environment="NODE_EXTRA_CA_CERTS={{.NodeExtraCACerts}}"
+{{end}}ExecStart=/usr/bin/env -S flowfuse-device-agent --dir {{.WorkDir}} --port {{.Port}}
 # Use SIGINT to stop
 KillSignal=SIGINT
 # Auto restart on crash
@@ -59,6 +60,8 @@ WORKING_DIR={{.WorkDir}}
 do_start() {
     log_daemon_msg "Starting $DESC" "$NAME"
     export NODE_OPTIONS="--max_old_space_size=512"
+{{if .NodeExtraCACerts}}    export NODE_EXTRA_CA_CERTS="{{.NodeExtraCACerts}}"
+{{end}}
     start-stop-daemon --start --quiet --background --user $USER --chdir $WORKING_DIR \
         --make-pidfile --pidfile $PIDFILE --startas /bin/bash \
         -- -c "exec $DAEMON $DAEMON_ARGS > $LOGFILE 2>&1"
@@ -135,7 +138,9 @@ const launchdTemplate = `<?xml version="1.0" encoding="UTF-8"?>
         <string>--max_old_space_size=512</string>
         <key>PATH</key>
         <string>{{.NodeBinDir}}:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-    </dict>
+{{if .NodeExtraCACerts}}        <key>NODE_EXTRA_CA_CERTS</key>
+        <string>{{.NodeExtraCACerts}}</string>
+{{end}}    </dict>
 </dict>
 </plist>`
 
@@ -151,7 +156,7 @@ description="FlowFuse Device Agent"
 supervisor="supervise-daemon"
 command="{{.NodeBinDir}}/flowfuse-device-agent"
 command_args="--dir {{.WorkDir}} --port {{.Port}}"
-supervise_daemon_args=" -d {{.WorkDir}} --stdout {{.LogFile}} --stderr {{.ErrorLogFile}} -e "PATH=\"{{.NodeBinDir}}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"\""
+supervise_daemon_args=" -d {{.WorkDir}} --stdout {{.LogFile}} --stderr {{.ErrorLogFile}} -e "PATH=\"{{.NodeBinDir}}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"\""{{if .NodeExtraCACerts}}" -e NODE_EXTRA_CA_CERTS=\"{{.NodeExtraCACerts}}\""{{end}}
 command_user="{{.User}}"
 
 depend() {

--- a/installer/go/pkg/service/windows.go
+++ b/installer/go/pkg/service/windows.go
@@ -58,7 +58,7 @@ func nssmDownloadURLs() []string {
 //
 // Returns:
 //   - error: nil on success, otherwise an error with detailed failure information
-func InstallWindows(serviceName, workDir string, port int) error {
+func InstallWindows(serviceName, workDir string, port int, caCertPath string) error {
 	// First, download and extract NSSM if it doesn't exist
 	nssmPath, err := ensureNSSM(workDir)
 	if err != nil {
@@ -83,7 +83,7 @@ func InstallWindows(serviceName, workDir string, port int) error {
 	}
 
 	// Configure the service
-	if err := configureService(nssmPath, serviceName, workDir, port); err != nil {
+	if err := configureService(nssmPath, serviceName, workDir, port, caCertPath); err != nil {
 		return err
 	}
 
@@ -100,7 +100,7 @@ func InstallWindows(serviceName, workDir string, port int) error {
 //
 // Returns:
 //   - error: nil on success, otherwise an error indicating the failure
-func configureService(nssmPath, serviceName, workDir string, port int) error {
+func configureService(nssmPath, serviceName, workDir string, port int, caCertPath string) error {
 	serviceParams := map[string]string{
 		"AppDirectory":                 workDir,
 		"DisplayName":                  fmt.Sprintf("FlowFuse Device Agent (%d)", port),
@@ -126,7 +126,11 @@ func configureService(nssmPath, serviceName, workDir string, port int) error {
 	// Configure environment variables
 	nodeOptions := "NODE_OPTIONS=--max_old_space_size=512"
 	// The AppEnvironmentExtra parameter needs multiple values, which requires a direct command
-	envCmd := exec.Command(nssmPath, "set", serviceName, "AppEnvironmentExtra", nodeOptions, os.Getenv("PATH"))
+	envValues := []string{"set", serviceName, "AppEnvironmentExtra", nodeOptions, os.Getenv("PATH")}
+	if caCertPath != "" {
+		envValues = append(envValues, "NODE_EXTRA_CA_CERTS="+caCertPath)
+	}
+	envCmd := exec.Command(nssmPath, envValues...)
 	logger.Debug("Set environment command: %s", envCmd.String())
 	if output, err := envCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to set environment variables: %w\nOutput: %s", err, output)

--- a/installer/go/pkg/utils/utils.go
+++ b/installer/go/pkg/utils/utils.go
@@ -1147,3 +1147,73 @@ func ShowInstallSummary(installMode, url, workDir string) {
 	logger.Info("  - To learn how to view logs, visit https://flowfuse.com/docs/device-agent/install/device-agent-installer/#viewing-device-agent-log-files")
 	logger.Info("")
 }
+
+// InstallCACertificate copies a CA certificate bundle into the working directory
+// and makes it readable by the service user, returning the path to the installed copy.
+//
+// The agent and the installer's npm/OTC steps run as the unprivileged service user
+// (or LocalService on Windows), which generally cannot read a path the admin exported
+// (e.g. under /root or a home directory). Copying the bundle into the working directory
+// and chowning it to the service user guarantees the CA is readable at both setup and
+// runtime. The returned path is what NODE_EXTRA_CA_CERTS should be set to.
+//
+// Parameters:
+//   - srcPath: The admin-provided CA bundle path (empty = no-op)
+//   - workDir: The working directory to copy the bundle into
+//
+// Returns:
+//   - string: The path to the installed CA bundle copy, or "" if srcPath was empty
+//   - error: An error if the source is missing/unreadable or the copy fails
+func InstallCACertificate(srcPath, workDir string) (string, error) {
+	if srcPath == "" {
+		return "", nil
+	}
+
+	info, err := os.Stat(srcPath)
+	if err != nil {
+		return "", fmt.Errorf("CA certificate %q is not accessible: %w", srcPath, err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("CA certificate %q is not a regular file", srcPath)
+	}
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read CA certificate %q: %w", srcPath, err)
+	}
+
+	destPath := filepath.Join(workDir, "ca-certificates.pem")
+
+	switch runtime.GOOS {
+	case "linux", "darwin":
+		tempFile, err := os.CreateTemp("", "flowfuse-ca-*.pem")
+		if err != nil {
+			return "", fmt.Errorf("failed to create temporary file: %w", err)
+		}
+		defer os.Remove(tempFile.Name())
+		if _, err := tempFile.Write(data); err != nil {
+			tempFile.Close()
+			return "", fmt.Errorf("failed to write temporary CA file: %w", err)
+		}
+		tempFile.Close()
+
+		if output, err := exec.Command("sudo", "cp", tempFile.Name(), destPath).CombinedOutput(); err != nil {
+			return "", fmt.Errorf("failed to copy CA certificate: %w\nOutput: %s", err, output)
+		}
+		if output, err := exec.Command("sudo", "chown", ServiceUsername, destPath).CombinedOutput(); err != nil {
+			return "", fmt.Errorf("failed to set CA certificate ownership: %w\nOutput: %s", err, output)
+		}
+		if output, err := exec.Command("sudo", "chmod", "644", destPath).CombinedOutput(); err != nil {
+			return "", fmt.Errorf("failed to set CA certificate permissions: %w\nOutput: %s", err, output)
+		}
+	case "windows":
+		// The working directory already grants LocalService Modify (see createDirWithPermissions).
+		if err := os.WriteFile(destPath, data, 0644); err != nil {
+			return "", fmt.Errorf("failed to copy CA certificate: %w", err)
+		}
+	default:
+		return "", fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
+	}
+
+	logger.Debug("Installed CA certificate to %s", destPath)
+	return destPath, nil
+}


### PR DESCRIPTION
## Description

This pull request introduces the `--ca-cert` flag to the Device Agent Installer that allows to pass the Certificate Authority certificate bundle file to be trusted by the Device Agent.
This change allows to quickly onboard the Remote Instance using the Installer in environments where self-signed certificates have been used to deploy the FlowFuse Platform.

## Related Issue(s)

Closes https://github.com/FlowFuse/device-agent/issues/698

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

