### PR TITLE
ci: Exclude the `installer` path from the main package release configuration

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -9,7 +9,8 @@
   "skip-pull-request": false,
   "packages": {
     ".": {
-      "release-type": "node"
+      "release-type": "node",
+      "exclude-paths": ["installer"]
     }
   }
 }


### PR DESCRIPTION
## Description

This pull request adds the `installer` path to the `exclude-paths` release configuration for the main package. In result, commits from this path are excluded when calculating next version of the Device Agent package. 

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

