### PR TITLE
fix: Ensure both snapshot and settings catalogues used

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -345,14 +345,11 @@ class Launcher {
         // if licensed, add palette catalogues
         if (this.config.licensed) {
             if (this.project) {
-                if (this.snapshot?.settings?.palette?.catalogue !== undefined) {
-                    settings.editorTheme.palette.catalogues = this.snapshot.settings.palette.catalogue
-                    // need to merge in settings catalogues and remove duplicates
-                    const temp = [...(this.settings?.palette?.catalogues || []), ...(this.snapshot.settings?.palette?.catalogue || [])]
-                    settings.editorTheme.palette.catalogues = temp.filter((item, pos, self) => {
-                        return self.indexOf(item) === pos
-                    })
-                }
+                // need to merge in settings catalogues and remove duplicates
+                const temp = [...(this.settings?.palette?.catalogues || []), ...(this.snapshot.settings?.palette?.catalogue || [])]
+                settings.editorTheme.palette.catalogues = temp.filter((item, pos, self) => {
+                    return self.indexOf(item) === pos
+                })
             } else if (this.application) {
                 if (this.settings.palette?.catalogues) {
                     settings.editorTheme.palette.catalogues = this.settings.palette.catalogues


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Currently the code only merges catalogue lists if the snapshot list exists, but the snapshot may not include any catalogues so the settings list gets dropped.

