### PR TITLE
fix: Use text in place of default enter glyph for terminals without that glyph

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,11 @@ const defaultInquirerTheme = {
     prefix: '',
     style: {
         // Give some spacing to the messages
-        message: (text, status) => { return '\n' + chalk.bold(text) + '\n' }
+        message: (text, status) => { return '\n' + chalk.bold(text) + '\n' },
+        // Avoid the '⏎' glyph - it renders as a missing-character box in some terminal fonts (displays the tofu character instead). Use <enter> instead.
+        keysHelpTip: (keys) => keys
+            .map(([key, action]) => `${chalk.bold(key === '⏎' ? '<enter>' : key)} ${chalk.dim(action)}`)
+            .join(chalk.dim(' • '))
     }
 }
 

--- a/lib/cli/flowsImporter.js
+++ b/lib/cli/flowsImporter.js
@@ -18,7 +18,11 @@ const defaultInquirerTheme = {
     prefix: '',
     style: {
         // Give some spacing to the messages
-        message: (text, status) => { return '\n' + chalk.bold(text) + '\n' }
+        message: (text, status) => { return '\n' + chalk.bold(text) + '\n' },
+        // Avoid the '⏎' glyph - it renders as a missing-character box in some terminal fonts (displays the tofu character instead). Use <enter> instead.
+        keysHelpTip: (keys) => keys
+            .map(([key, action]) => `${chalk.bold(key === '⏎' ? '<enter>' : key)} ${chalk.dim(action)}`)
+            .join(chalk.dim(' • '))
     }
 }
 


### PR DESCRIPTION

## Description

Replace  ⏎ glyph with text "<enter>" 

### Before
<img width="902" height="230" alt="image" src="https://github.com/user-attachments/assets/168b6002-58b2-42d2-808f-802fd6e129b3" />

### After
<img width="702" height="180" alt="image" src="https://github.com/user-attachments/assets/a3c6399f-9fd6-4cae-b18b-d9420930563f" />


## Related Issue(s)

closes #712

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

